### PR TITLE
Autocomplete the relative path while renaming

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1164,7 +1164,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "xplr"
-version = "0.2.20"
+version = "0.2.21"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xplr"
-version = "0.2.20"  # Update app.rs
+version = "0.2.21"  # Update app.rs
 authors = ["Arijit Basu <sayanarijit@gmail.com>"]
 edition = "2018"
 description = "A hackable, minimal, fast TUI file explorer, stealing ideas from nnn and fzf"

--- a/src/app.rs
+++ b/src/app.rs
@@ -12,7 +12,7 @@ use std::fs;
 use std::io;
 use std::path::PathBuf;
 
-pub const VERSION: &str = "v0.2.20"; // Update Cargo.toml
+pub const VERSION: &str = "v0.2.21"; // Update Cargo.toml
 
 pub const TEMPLATE_TABLE_ROW: &str = "TEMPLATE_TABLE_ROW";
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -331,7 +331,7 @@ impl Default for KeyBindings {
                 messages:
                   - SwitchMode: rename
                   - BashExec: |
-                      echo "SetInputBuffer: ${XPLR_FOCUS_PATH}" >> "${XPLR_PIPE_MSG_IN:?}"
+                      echo "SetInputBuffer: $(basename ${XPLR_FOCUS_PATH})" >> "${XPLR_PIPE_MSG_IN:?}"
 
               ".":
                 help: show hidden
@@ -874,7 +874,7 @@ impl Default for Config {
                     help: rename
                     messages:
                       - BashExec: |
-                          SRC="$(basename ${XPLR_FOCUS_PATH:?})"
+                          SRC="${XPLR_FOCUS_PATH:?}"
                           TARGET="${XPLR_INPUT_BUFFER:?}"
                           if mv -v "${SRC:?}" "${TARGET:?}"; then
                             echo "LogSuccess: $SRC renamed to $TARGET" >> "${XPLR_PIPE_MSG_IN:?}"


### PR DESCRIPTION
By default, while renaming a file, autocomplete the relative path i.e.
the filename instead of the absolute path in the input buffer.

(In reality, this PR is intended to test the CD pipeline).