### PR TITLE
Fix large env vars breaking the subprocess

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1164,7 +1164,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "xplr"
-version = "0.2.21"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xplr"
-version = "0.2.21"  # Update app.rs
+version = "0.3.0"  # Update app.rs
 authors = ["Arijit Basu <sayanarijit@gmail.com>"]
 edition = "2018"
 description = "A hackable, minimal, fast TUI file explorer, stealing ideas from nnn and fzf"

--- a/src/config.rs
+++ b/src/config.rs
@@ -354,7 +354,7 @@ impl Default for KeyBindings {
                 help: global help menu
                 messages:
                   - BashExec: |
-                      echo -e "${XPLR_GLOBAL_HELP_MENU}"
+                      cat "${XPLR_PIPE_GLOBAL_HELP_MENU_OUT}"
                       echo
                       read -p "[enter to continue]"
 
@@ -627,7 +627,7 @@ impl Default for Config {
                     help: logs
                     messages:
                       - BashExec: |
-                          echo -e "$XPLR_LOGS"
+                          cat "${XPLR_PIPE_LOGS_OUT}"
                           read -p "[enter to continue]"
                       - SwitchMode: default
 
@@ -662,7 +662,7 @@ impl Default for Config {
                             else
                               echo "LogError: failed to copy $line to $PWD" >> "${XPLR_PIPE_MSG_IN:?}"
                             fi
-                          done <<< "${XPLR_SELECTION:?}")
+                          done < "${XPLR_PIPE_SELECTION_OUT:?}")
                           echo Explore >> "${XPLR_PIPE_MSG_IN:?}"
                           echo ClearSelection >> "${XPLR_PIPE_MSG_IN:?}"
                           read -p "[enter to continue]"
@@ -678,7 +678,7 @@ impl Default for Config {
                             else
                               echo "LogError: failed to move $line to $PWD" >> "${XPLR_PIPE_MSG_IN:?}"
                             fi
-                          done <<< "${XPLR_SELECTION:?}")
+                          done < "${XPLR_PIPE_SELECTION_OUT:?}")
                           echo Explore >> "${XPLR_PIPE_MSG_IN:?}"
                           read -p "[enter to continue]"
                       - SwitchMode: default
@@ -929,7 +929,7 @@ impl Default for Config {
                                 echo "LogError: failed to delete $line" >> "${XPLR_PIPE_MSG_IN:?}"
                               fi
                             fi
-                          done <<< "${XPLR_RESULT:?}")
+                          done < "${XPLR_PIPE_RESULT_OUT:?}")
                           echo Explore >> "${XPLR_PIPE_MSG_IN:?}"
                           read -p "[enter to continue]"
                       - SwitchMode: default
@@ -944,7 +944,7 @@ impl Default for Config {
                             else
                               echo "LogError: failed to delete $line" >> "${XPLR_PIPE_MSG_IN:?}"
                             fi
-                          done <<< "${XPLR_RESULT:?}")
+                          done < "${XPLR_PIPE_RESULT_OUT:?}")
                           echo Explore >> "${XPLR_PIPE_MSG_IN:?}"
                           read -p "[enter to continue]"
                       - SwitchMode: default

--- a/src/explorer.rs
+++ b/src/explorer.rs
@@ -27,7 +27,7 @@ pub fn explore(
                     })
                 })
                 .map(|name| Node::new(parent.clone(), name))
-                .filter(|n| config.apply(n))
+                .filter(|n| config.filter(n))
                 .collect::<Vec<Node>>()
             })
             .map(|nodes| {


### PR DESCRIPTION
Bug:
When you call some command in a directory with a large number of hosts,
xplr will fail setting the environment vars as the command will become
too large to handle.

Fix:
Port the value of multi-line variables from env vars to pipes and set
the name of the pipe as env var instead. And deprecate the variables
that doesn't make much sense.

In other words,

- `$XPLR_APP_YAML` has been removed.
- `$XPLR_RESULT` has been ported to `$XPLR_PIPE_RESULT_OUT`.
- `$XPLR_GLOBAL_HELP_MENU` has been ported to
  `$XPLR_PIPE_GLOBAL_HELP_MENU_OUT`.
- `$XPLR_DIRECTORY_NODES` has been ported to
  `$XPLR_PIPE_DIRECTORY_NODES_OUT`.
- `$XPLR_LOGS` has been ported to `$XPLR_PIPE_LOGS_OUT`.
- `$XPLR_PIPE_RESULT` has been ported to `$XPLR_PIPE_RESULT_OUT`.

Hence, instead of `<<< $VAR`, `< $VAR_PIPE_OUT` should be used.