### PR TITLE
Improve version incompatibility error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1164,7 +1164,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "xplr"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xplr"
-version = "0.3.0"  # Update app.rs
+version = "0.3.1"  # Update app.rs
 authors = ["Arijit Basu <sayanarijit@gmail.com>"]
 edition = "2018"
 description = "A hackable, minimal, fast TUI file explorer, stealing ideas from nnn and fzf"

--- a/tests/test_version.rs
+++ b/tests/test_version.rs
@@ -1,0 +1,14 @@
+use xplr::*;
+
+#[test]
+fn test_version_incompatibility() {
+    assert!(app::is_compatible("v0.1.0", "v0.1.2"));
+    assert!(app::is_compatible("v0.2.0", "v0.2.2"));
+    assert!(!app::is_compatible("v0.1.0", "v0.2.0"));
+    assert!(!app::is_compatible("v0.1.0", "v1.1.0"));
+    assert!(app::is_compatible("v1.1.0", "v1.1.0"));
+    assert!(app::is_compatible("v1.1.0", "v1.1.1"));
+    assert!(app::is_compatible("v1.1.0", "v1.2.1"));
+    assert!(app::is_compatible("v1.1.0", "v1.2.1"));
+    assert!(!app::is_compatible("v1.1.0", "v2.0.0"));
+}


### PR DESCRIPTION
With this change, `xplr` will only raise version incompatibility error
if the major version changes. Minor version updates are assumed to be
backwards compatible.

If the major version is `v0`, the minor version will be considered as
the major version and the security/patch version will be considered as
minor version and the same logic will apply.