### PR TITLE
Add XPLR_APP_VERSION and XPLR_CONFIG_VERSION

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -720,6 +720,7 @@ pub fn is_compatible(existing: &str, required: &str) -> bool {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct App {
+    version: String,
     config: Config,
     pwd: String,
     directory_buffers: HashMap<String, DirectoryBuffer>,
@@ -786,6 +787,7 @@ impl App {
         }
 
         Ok(Self {
+            version: VERSION.to_string(),
             config,
             pwd: pwd.to_string_lossy().to_string(),
             directory_buffers: Default::default(),
@@ -1392,5 +1394,10 @@ impl App {
             })
             .collect::<Vec<String>>()
             .join("\n")
+    }
+
+    /// Get a reference to the app's version.
+    pub fn version(&self) -> &String {
+        &self.version
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -174,6 +174,8 @@ fn main() -> Result<()> {
 
                     let status = std::process::Command::new(cmd.command.clone())
                         .current_dir(app.pwd())
+                        .env("XPLR_APP_VERSION", app.version())
+                        .env("XPLR_CONFIG_VERSION", &app.config().version)
                         .env("XPLR_PID", pid)
                         .env("XPLR_INPUT_BUFFER", input_buffer)
                         .env("XPLR_FOCUS_PATH", focus_path)


### PR DESCRIPTION
Since users don't need to update config file version for minor app
releases, we have to differentiate between app and config version.

Also, expose them via `$XPLR_CONFIG_VERSION` and `$XPLR_APP_VERSION`.