### PR TITLE
Improve search and filter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1164,7 +1164,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "xplr"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xplr"
-version = "0.3.7"  # Update app.rs and default.nix
+version = "0.3.8"  # Update app.rs and default.nix
 authors = ["Arijit Basu <sayanarijit@gmail.com>"]
 edition = "2018"
 description = "A hackable, minimal, fast TUI file explorer, stealing ideas from nnn and fzf"

--- a/default.nix
+++ b/default.nix
@@ -4,9 +4,9 @@ with import <nixpkgs> { };
 
 rustPlatform.buildRustPackage rec {
   name = "xplr";
-  version = "0.3.7";
+  version = "0.3.8";
   src = fetchTarball
-    ("https://github.com/sayanarijit/xplr/archive/refs/tags/v0.3.7.tar.gz");
+    ("https://github.com/sayanarijit/xplr/archive/refs/tags/v0.3.8.tar.gz");
   buildInputs = [ cargo ];
   checkPhase = "";
   cargoSha256 = "0000000000000000000000000000000000000000000000000000";

--- a/src/config.rs
+++ b/src/config.rs
@@ -293,14 +293,12 @@ impl Default for KeyBindings {
               ctrl-f:
                 help: search [/]
                 messages:
-                  - ResetNodeFilters
                   - SwitchMode: search
                   - SetInputBuffer: ""
                   - Explore
 
               /:
                 messages:
-                  - ResetNodeFilters
                   - SwitchMode: search
                   - SetInputBuffer: ""
                   - Explore
@@ -502,7 +500,9 @@ impl Default for Config {
                   enter:
                     help: focus
                     messages:
-                      - ResetNodeFilters
+                      - RemoveNodeFilterFromInput:
+                          filter: RelativePathDoesContain
+                          case_sensitive: false
                       - SwitchMode: default
                       - Explore
                   
@@ -519,7 +519,9 @@ impl Default for Config {
                   right:
                     help: enter
                     messages:
-                      - ResetNodeFilters
+                      - RemoveNodeFilterFromInput:
+                          filter: RelativePathDoesContain
+                          case_sensitive: false
                       - Enter
                       - SwitchMode: default
                       - Explore
@@ -527,7 +529,9 @@ impl Default for Config {
                   left:
                     help: back
                     messages:
-                      - ResetNodeFilters
+                      - RemoveNodeFilterFromInput:
+                          filter: RelativePathDoesContain
+                          case_sensitive: false
                       - Back
                       - SwitchMode: default
                       - Explore
@@ -535,15 +539,19 @@ impl Default for Config {
                   esc:
                     help: cancel
                     messages:
-                      - ResetNodeFilters
+                      - RemoveNodeFilterFromInput:
+                          filter: RelativePathDoesContain
+                          case_sensitive: false
                       - SwitchMode: default
                       - Explore
 
                   backspace:
                     help: clear
                     messages:
+                      - RemoveNodeFilterFromInput:
+                          filter: RelativePathDoesContain
+                          case_sensitive: false
                       - SetInputBuffer: ""
-                      - ResetNodeFilters
                       - Explore
 
                   ctrl-c:
@@ -553,8 +561,10 @@ impl Default for Config {
 
                 default:
                   messages:
+                    - RemoveNodeFilterFromInput:
+                        filter: RelativePathDoesContain
+                        case_sensitive: false
                     - BufferInputFromKey
-                    - ResetNodeFilters
                     - AddNodeFilterFromInput:
                         filter: RelativePathDoesContain
                         case_sensitive: false


### PR DESCRIPTION
Concern:
Using `ResetNodeFilters` to clear the filters while searching or exiting
from search unexpectedly resets the `show hidden` mode because the
action not only removes the target filter, it resets all the other
filters as well.

Solution:
Implement `RemoveNodeFilterFromInput` to be able to clear or remove
target filters without having to reset it.