### PR TITLE
Don't quit on esc

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -362,10 +362,6 @@ impl Default for KeyBindings {
               q:
                 messages:
                   - Terminate
-
-              esc:
-                messages:
-                  - Terminate
             "###,
         )
         .unwrap();


### PR DESCRIPTION
Issue:
`esc` is generally used to get back to the `default` mode and mistakenly
pressing `esc` while in `default` mode will annoyingly terminate the
session.

Fix:
Remove `esc` from the `default` mode's key bindings. Use `q` or `crtl-c`
instead.