### PR TITLE
Stay in search mode when entering or leaving a directory

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -517,7 +517,7 @@ impl Default for Config {
                           filter: RelativePathDoesContain
                           case_sensitive: false
                       - Enter
-                      - SwitchMode: default
+                      - SetInputBuffer: ""
                       - Explore
 
                   left:
@@ -527,7 +527,7 @@ impl Default for Config {
                           filter: RelativePathDoesContain
                           case_sensitive: false
                       - Back
-                      - SwitchMode: default
+                      - SetInputBuffer: ""
                       - Explore
 
                   esc:


### PR DESCRIPTION
This might be a little counter intuitive to the `nnn` users, but I think
this will add to the productivity and should be the default.

Since we have a real-time mode indicator, users shouldn't face much of
an issue switching to the alternate default.