### PR TITLE
Fix symlink support

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -97,8 +97,6 @@ impl Node {
     pub fn new(parent: String, relative_path: String) -> Self {
         let absolute_path = PathBuf::from(&parent)
             .join(&relative_path)
-            .canonicalize()
-            .unwrap_or_default()
             .to_string_lossy()
             .to_string();
 
@@ -109,7 +107,7 @@ impl Node {
             .map(|e| e.to_string_lossy().to_string())
             .unwrap_or_default();
 
-        let maybe_metadata = path.metadata().ok();
+        let maybe_metadata = path.symlink_metadata().ok();
 
         let is_symlink = maybe_metadata
             .clone()


### PR DESCRIPTION
[canonicalize()](https://doc.rust-lang.org/std/fs/fn.canonicalize.html) and [metadata()](https://doc.rust-lang.org/std/fs/fn.metadata.html) both resolve symlinks, thus showing symlinks as regular files

By the way, would be nice to be able to show in the UI the destination of the symlink, and potentially also whether symlink leads to a directory or to a file (i.e. can be entered by pressing `l`).

And goes without saying: awesome project!! 🚀 