### PR TITLE
Add support for custom metadata for table row UI

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -24,6 +24,8 @@ pub struct FileTypeConfig {
     pub icon: String,
     #[serde(default)]
     pub style: Style,
+    #[serde(default)]
+    pub custom: HashMap<String, String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -50,11 +52,13 @@ impl Default for FileTypesConfig {
                 style: Style::default()
                     .add_modifier(Modifier::BOLD)
                     .fg(Color::Cyan),
+                custom: Default::default(),
             },
 
             file: FileTypeConfig {
                 icon: "ƒ".into(),
                 style: Default::default(),
+                custom: Default::default(),
             },
 
             symlink: FileTypeConfig {
@@ -62,6 +66,7 @@ impl Default for FileTypesConfig {
                 style: Style::default()
                     .add_modifier(Modifier::ITALIC)
                     .fg(Color::Cyan),
+                custom: Default::default(),
             },
 
             mime_essence: Default::default(),

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -4,6 +4,7 @@ use crate::app::Node;
 use handlebars::Handlebars;
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
+use std::collections::HashMap;
 use tui::backend::Backend;
 use tui::layout::Rect;
 use tui::layout::{Constraint as TuiConstraint, Direction, Layout};
@@ -41,6 +42,7 @@ struct NodeUiMetadata {
     pub is_selected: bool,
     pub is_focused: bool,
     pub total: usize,
+    pub custom: HashMap<String, String>,
 }
 
 impl NodeUiMetadata {
@@ -57,6 +59,7 @@ impl NodeUiMetadata {
         is_selected: bool,
         is_focused: bool,
         total: usize,
+        custom: HashMap<String, String>,
     ) -> Self {
         Self {
             parent: node.parent.clone(),
@@ -79,6 +82,7 @@ impl NodeUiMetadata {
             is_selected,
             is_focused,
             total,
+            custom,
         }
     }
 }
@@ -168,6 +172,7 @@ fn draw_table<B: Backend>(f: &mut Frame<B>, rect: Rect, app: &app::App, hb: &Han
                         is_selected,
                         is_focused,
                         dir.total,
+                        filetype.custom.clone(),
                     );
 
                     let cols = hb


### PR DESCRIPTION
Example:

```yaml
filetypes:
  directory:
    custom:
      foo: bar
     ...
```

Where `foo` and `bar` can be anything string.

It can be accessed with the `{{{custom.foo}}}` variable.