### PR TITLE
Fixed error preventing compilation

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -370,7 +370,7 @@ impl Key {
                 | Self::Num6
                 | Self::Num7
                 | Self::Num8
-                | Self::Num9,
+                | Self::Num9
         )
     }
 


### PR DESCRIPTION
Removed comma.

Error was as follows:
error: no rules expected the token `,`
   --> src/input.rs:373:29
    |
373 |                 | Self::Num9,
    |                             ^ no rules expected this token in macro call

error: aborting due to previous error