### PR TITLE
Fix remap behaviour and help menu

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1846,7 +1846,7 @@ dependencies = [
 
 [[package]]
 name = "xplr"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xplr"
-version = "0.4.0"  # Update default_config.rs and default.nix
+version = "0.4.1"  # Update default_config.rs and default.nix
 authors = ["Arijit Basu <sayanarijit@gmail.com>"]
 edition = "2018"
 description = "A hackable, minimal, fast TUI file explorer, stealing ideas from nnn and fzf"

--- a/default.nix
+++ b/default.nix
@@ -4,9 +4,9 @@ with import <nixpkgs> {};
 
 rustPlatform.buildRustPackage rec {
   name = "xplr";
-  version = "0.4.0";
+  version = "0.4.1";
   src = fetchTarball
-    ("https://github.com/sayanarijit/xplr/archive/refs/tags/v0.4.0.tar.gz");
+    ("https://github.com/sayanarijit/xplr/archive/refs/tags/v0.4.1.tar.gz");
   buildInputs = [ cargo ];
   checkPhase = "";
   cargoSha256 = "0000000000000000000000000000000000000000000000000000";

--- a/src/app.rs
+++ b/src/app.rs
@@ -2,7 +2,7 @@ use crate::config::Config;
 use crate::config::Mode;
 use crate::input::Key;
 use anyhow::{bail, Result};
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, Local};
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 use std::collections::HashMap;
@@ -668,7 +668,7 @@ pub enum LogLevel {
 pub struct Log {
     pub level: LogLevel,
     pub message: String,
-    pub created_at: DateTime<Utc>,
+    pub created_at: DateTime<Local>,
 }
 
 impl Log {
@@ -676,7 +676,7 @@ impl Log {
         Self {
             level,
             message,
-            created_at: Utc::now(),
+            created_at: Local::now(),
         }
     }
 }
@@ -892,9 +892,10 @@ impl App {
         let key_str = key.to_string();
         let default = kb.default.clone();
         let msgs = kb
-            .on_key
+            .remaps
             .get(&key_str)
-            .or_else(|| kb.remaps.get(&key_str).and_then(|k| kb.on_key.get(k)))
+            .and_then(|k| kb.on_key.get(k))
+            .or_else(|| kb.on_key.get(&key_str))
             .map(|a| Some(a.messages.clone()))
             .unwrap_or_else(|| {
                 if key.is_alphabet() {

--- a/src/config.rs
+++ b/src/config.rs
@@ -368,9 +368,15 @@ impl Mode {
                 extra_help_lines
                     .unwrap_or_default()
                     .into_iter()
-                    .chain(self.key_bindings.on_key.iter().filter_map(|(k, a)| {
-                        a.help.clone().map(|h| HelpMenuLine::KeyMap(k.into(), h))
-                    }))
+                    .chain(
+                        self.key_bindings
+                            .on_key
+                            .iter()
+                            .filter(|(k, _)| !self.key_bindings.remaps.contains_key(&k.to_string()))
+                            .filter_map(|(k, a)| {
+                                a.help.clone().map(|h| HelpMenuLine::KeyMap(k.into(), h))
+                            }),
+                    )
                     .chain(
                         self.key_bindings
                             .on_alphabet
@@ -553,6 +559,7 @@ impl Config {
 
     pub fn is_compatible(&self) -> Result<bool> {
         let result = match self.parsed_version()? {
+            (0, 4, 1) => true,
             (0, 4, 0) => true,
             (_, _, _) => false,
         };
@@ -562,7 +569,7 @@ impl Config {
 
     pub fn upgrade_notification(&self) -> Result<Option<&str>> {
         let result = match self.parsed_version()? {
-            (0, 4, 0) => None,
+            (0, 4, 1) => None,
             (_, _, _) => Some("New version available"),
         };
 

--- a/src/config.yml
+++ b/src/config.yml
@@ -1,4 +1,4 @@
-version: v0.4.0
+version: v0.4.1
 general:
   show_hidden: false
   prompt:

--- a/src/main.rs
+++ b/src/main.rs
@@ -93,20 +93,6 @@ fn main() -> Result<()> {
 
     let mut app = app::App::create(pwd)?;
 
-    if app.version() != &app.config().version {
-        let msg = format!(
-            "you can update your config file version from {} to {}, visit {} for more info.",
-            app.config().version,
-            app.version(),
-            app::UPGRADE_GUIDE_LINK,
-        );
-
-        tx_msg_in.send(app::Task::new(
-            app::MsgIn::External(app::ExternalMsg::LogInfo(msg)),
-            None,
-        ))?;
-    };
-
     fs::write(&app.pipe().global_help_menu_out, app.global_help_menu_str())?;
 
     explorer::explore(

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -345,15 +345,15 @@ fn draw_logs<B: Backend>(f: &mut Frame<B>, rect: Rect, app: &app::App, _: &Handl
         .rev()
         .take(1)
         .rev()
-        .map(|l| match &l.level {
-            app::LogLevel::Info => {
-                ListItem::new(l.message.clone()).style(Style::default().fg(Color::Gray))
-            }
-            app::LogLevel::Success => {
-                ListItem::new(l.message.clone()).style(Style::default().fg(Color::Green))
-            }
-            app::LogLevel::Error => {
-                ListItem::new(l.message.clone()).style(Style::default().fg(Color::Red))
+        .map(|l| {
+            let time = l.created_at.format("%r");
+            let log = format!("{} | {}", &time, l.message);
+            match &l.level {
+                app::LogLevel::Info => ListItem::new(log).style(Style::default().fg(Color::Gray)),
+                app::LogLevel::Success => {
+                    ListItem::new(log).style(Style::default().fg(Color::Green))
+                }
+                app::LogLevel::Error => ListItem::new(log).style(Style::default().fg(Color::Red)),
             }
         })
         .collect::<Vec<ListItem>>();


### PR DESCRIPTION
Remapping a key should overwrite default. Also, remapped keys shouldn't
be redundantly visible in help menu.

Also, display log time.