### PR TITLE
Add desktop file

### DIFF
--- a/xplr.desktop
+++ b/xplr.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Type=Application
+Name=xplr
+Comment=Terminal file manager
+Exec=xplr
+Terminal=true
+Icon=xplr
+MimeType=inode/directory
+Categories=System;FileTools;FileManager;ConsoleOnly
+Keywords=File;Manager;Management;Explorer;Launcher


### PR DESCRIPTION
I continue my migration from `nnn`, this is a copy-paste from their repo basically. This allows you to launch `xplr` from a launcher, but also if you have `inode/directory=xplr.desktop` in `~/.config/mimeapps.list` you can just do `xdg-open /path/to/folder` and explore the folder in a new terminal.

cc @orhun once merged, could you please update the pkgs to get this installed to `/usr/share/applications/xplr.desktop`?

We dont have an icon of course, so we can drop `Icon=`, or it can stay (it doesn't hurt) and remind us that an icon is needed 😛 

FYI if you come up with an icon, just put it in the repo, we would need to install the icons to this location and then it will magically work (again this is how nnn does this) 🙂 

```
/usr/share/icons/hicolor/64x64/apps/xplr.png
/usr/share/icons/hicolor/scalable/apps/xplr.svg
```