### PR TITLE
Fix panic on permission denied

### DIFF
--- a/src/config.yml
+++ b/src/config.yml
@@ -165,7 +165,7 @@ node_types:
       icon: ƒ
   symlink:
     style:
-      fg: Cyan
+      fg: Magenta
       bg: null
       add_modifier:
         bits: 4

--- a/src/pwd_watcher.rs
+++ b/src/pwd_watcher.rs
@@ -18,10 +18,24 @@ pub fn keep_watching(
     let mut last_pwd = pwd.to_string();
     thread::spawn(move || loop {
         if let Ok(new_pwd) = rx_pwd_watcher.try_recv() {
-            watcher.unwatch(&last_pwd).unwrap();
+            watcher.unwatch(&last_pwd).unwrap_or_else(|e| {
+                tx_msg_in
+                    .send(Task::new(
+                        MsgIn::External(ExternalMsg::LogError(e.to_string())),
+                        None,
+                    ))
+                    .unwrap();
+            });
             watcher
                 .watch(&new_pwd, RecursiveMode::NonRecursive)
-                .unwrap();
+                .unwrap_or_else(|e| {
+                    tx_msg_in
+                        .send(Task::new(
+                            MsgIn::External(ExternalMsg::LogError(e.to_string())),
+                            None,
+                        ))
+                        .unwrap();
+                });
             last_pwd = new_pwd;
         } else {
             thread::sleep(Duration::from_secs(1));


### PR DESCRIPTION
Issue:
$PWD watch service panics when visiting restricted directories.

Fix:
Log error instead of panic.