### PR TITLE
Fix follow symlink behavior.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1630,7 +1630,7 @@ dependencies = [
 
 [[package]]
 name = "xplr"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xplr"
-version = "0.5.1"  # Update config.yml, config.rs and default.nix
+version = "0.5.2"  # Update config.yml, config.rs and default.nix
 authors = ["Arijit Basu <sayanarijit@gmail.com>"]
 edition = "2018"
 description = "A hackable, minimal, fast TUI file explorer"

--- a/src/config.rs
+++ b/src/config.rs
@@ -665,6 +665,7 @@ impl Config {
 
     pub fn is_compatible(&self) -> Result<bool> {
         let result = match self.parsed_version()? {
+            (0, 5, 2) => true,
             (0, 5, 1) => true,
             (0, 5, 0) => true,
             (_, _, _) => false,
@@ -675,7 +676,8 @@ impl Config {
 
     pub fn upgrade_notification(&self) -> Result<Option<&str>> {
         let result = match self.parsed_version()? {
-            (0, 5, 1) => None,
+            (0, 5, 2) => None,
+            (0, 5, 1) => Some("App version updated. Now follow symlinks using 'gf'."),
             (_, _, _) => Some("App version updated. New: added sort and filter support and some hacks: https://github.com/sayanarijit/xplr/wiki/Hacks"),
         };
 

--- a/src/config.yml
+++ b/src/config.yml
@@ -1,4 +1,4 @@
-version: v0.5.1
+version: v0.5.2
 general:
   show_hidden: false
   read_only: false
@@ -916,6 +916,11 @@ modes:
             help: top
             messages:
               - FocusFirst
+              - SwitchMode: default
+          f:
+            help: follow symlink
+            messages:
+              - FollowSymlink
               - SwitchMode: default
           x:
             help: open in gui


### PR DESCRIPTION
Use `gf` to follow symlinks instead of `enter`/`l`.

Or use the message `FollowSymlink`.