### PR TITLE
Fix terminal output redirection when piping stdout

### DIFF
--- a/src/runner.rs
+++ b/src/runner.rs
@@ -46,7 +46,7 @@ fn call(app: &app::App, cmd: app::Command, silent: bool) -> io::Result<ExitStatu
     let (stdin, stdout, stderr) = if silent {
         (Stdio::null(), Stdio::null(), Stdio::null())
     } else {
-        (Stdio::inherit(), Stdio::inherit(), Stdio::inherit())
+        (get_tty()?.into(), get_tty()?.into(), get_tty()?.into())
     };
 
     Command::new(cmd.command.clone())


### PR DESCRIPTION
Now, when you do `xplr > out.txt` and invoke the terminal, the stdout
won't be redirected.