### PR TITLE
Fix `cd` on first focus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1630,7 +1630,7 @@ dependencies = [
 
 [[package]]
 name = "xplr"
-version = "0.5.11"
+version = "0.5.12"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xplr"
-version = "0.5.11"  # Update config.yml, config.rs and default.nix
+version = "0.5.12"  # Update config.yml, config.rs and default.nix
 authors = ["Arijit Basu <sayanarijit@gmail.com>"]
 edition = "2018"
 description = "A hackable, minimal, fast TUI file explorer"

--- a/src/app.rs
+++ b/src/app.rs
@@ -1451,13 +1451,12 @@ impl App {
             explorer_config.sorters = sorters.clone();
         };
 
-        let mut history = History::default();
-        history = history.push(pwd.to_string_lossy().to_string());
+        let pwd = pwd.to_string_lossy().to_string();
 
         let mut app = Self {
             version: Config::default().version().clone(),
             config: config.clone(),
-            pwd: pwd.to_string_lossy().to_string(),
+            pwd: pwd.clone(),
             directory_buffers: Default::default(),
             selection: Default::default(),
             msg_out: Default::default(),
@@ -1468,8 +1467,9 @@ impl App {
             pipe: Pipe::from_session_path(&session_path)?,
             explorer_config,
             logs: Default::default(),
-            history,
-        };
+            history: Default::default(),
+        }
+        .change_directory(&pwd)?;
 
         if let Some(notif) = config.upgrade_notification()? {
             let notif = format!(


### PR DESCRIPTION
Fix issue where running `xplr /path/to/file` doesn't `cd` into the
parent directory.