### PR TITLE
Disown GUI process

### DIFF
--- a/src/config.yml
+++ b/src/config.yml
@@ -937,6 +937,7 @@ modes:
                     fi
                   fi
                   $OPENER "${XPLR_FOCUS_PATH:?}" &> /dev/null &
+                  disown
               - SwitchMode: default
               - ClearScreen
               - Refresh


### PR DESCRIPTION
With this fix, apps opened in GUI via the `gx` key binding will stay
open even after the `xplr` terminal is closed.