### PR TITLE
Add feature dynamic UI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1630,7 +1630,7 @@ dependencies = [
 
 [[package]]
 name = "xplr"
-version = "0.5.13"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xplr"
-version = "0.5.13"  # Update config.yml, config.rs and default.nix
+version = "0.6.0"  # Update config.yml, config.rs and default.nix
 authors = ["Arijit Basu <sayanarijit@gmail.com>"]
 edition = "2018"
 description = "A hackable, minimal, fast TUI file explorer"

--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ Table of content
 <img height=240 width=360 src="https://s3.gifyu.com/images/xplr-serve.gif" />
 </a>
 
-<a href="https://github.com/sayanarijit/xplr/wiki/Hacks#disk-usage-dua-cli" target="_blank">
-<img height=240 width=360 src="https://s4.gifyu.com/images/xplr-dua.gif" />
+<a href="https://github.com/sayanarijit/xplr/wiki/Themes#material-landscape" target="_blank">
+<img height=240 width=360 src="https://s3.gifyu.com/images/theaming.gif" />
 </a>
 
 <a href="https://github.com/sayanarijit/xplr/wiki/Hacks#sendreceive-files-via-qr-code-on-lan" target="_blank">

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,6 +4,7 @@ use crate::app::NodeFilter;
 use crate::app::NodeSorter;
 use crate::app::NodeSorterApplicable;
 use crate::default_config;
+use crate::ui::Border;
 use crate::ui::Style;
 use anyhow::Result;
 use indexmap::IndexSet;
@@ -12,7 +13,6 @@ use std::collections::BTreeMap;
 use std::collections::HashMap;
 use tui::layout::Constraint as TuiConstraint;
 use tui::layout::Rect;
-use tui::widgets::Borders as TuiBorders;
 
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -74,8 +74,8 @@ impl NodeTypeConfig {
     }
 
     /// Get a reference to the node type config's style.
-    pub fn style(&self) -> Style {
-        self.style
+    pub fn style(&self) -> &Style {
+        &self.style
     }
 
     /// Get a reference to the node type config's meta.
@@ -180,8 +180,8 @@ impl UiConfig {
     }
 
     /// Get a reference to the ui config's style.
-    pub fn style(&self) -> Style {
-        self.style
+    pub fn style(&self) -> &Style {
+        &self.style
     }
 }
 
@@ -208,8 +208,8 @@ impl UiElement {
     }
 
     /// Get a reference to the ui element's style.
-    pub fn style(&self) -> Style {
-        self.style
+    pub fn style(&self) -> &Style {
+        &self.style
     }
 }
 
@@ -240,8 +240,8 @@ impl TableRowConfig {
     }
 
     /// Get a reference to the table row config's style.
-    pub fn style(&self) -> Style {
-        self.style
+    pub fn style(&self) -> &Style {
+        &self.style
     }
 
     /// Get a reference to the table row config's height.
@@ -348,8 +348,8 @@ impl TableConfig {
     }
 
     /// Get a reference to the table config's style.
-    pub fn style(&self) -> Style {
-        self.style
+    pub fn style(&self) -> &Style {
+        &self.style
     }
 
     /// Get a reference to the table config's tree.
@@ -1027,26 +1027,6 @@ impl ModesConfig {
     }
 }
 
-#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq, PartialOrd, Ord, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub enum Border {
-    Top,
-    Right,
-    Bottom,
-    Left,
-}
-
-impl Border {
-    pub fn bits(self) -> u32 {
-        match self {
-            Self::Top => TuiBorders::TOP.bits(),
-            Self::Right => TuiBorders::RIGHT.bits(),
-            Self::Bottom => TuiBorders::BOTTOM.bits(),
-            Self::Left => TuiBorders::LEFT.bits(),
-        }
-    }
-}
-
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct LayoutOptions {
@@ -1115,8 +1095,8 @@ impl BlockConfig {
     }
 
     /// Get a reference to the block config's style.
-    pub fn style(&self) -> Style {
-        self.style
+    pub fn style(&self) -> &Style {
+        &self.style
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1045,6 +1045,7 @@ impl LayoutOptions {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub enum Layout {
+    Nothing,
     Table,
     InputAndLogs,
     Selection,
@@ -1062,7 +1063,7 @@ pub enum Layout {
 
 impl Default for Layout {
     fn default() -> Self {
-        Self::Table
+        Self::Nothing
     }
 }
 
@@ -1096,6 +1097,7 @@ impl Layout {
                 config: sc.extend(oc),
                 splits: os,
             },
+            (s, Self::Nothing) => s,
             (_, other) => other,
         }
     }

--- a/src/config.yml
+++ b/src/config.yml
@@ -22,9 +22,6 @@ layouts:
                 - SortAndFilter:
                     borders: [Top, Right, Bottom, Left]
                 - Table:
-                    title:
-                      style:
-                        fg: Red
                     borders: [Top, Right, Bottom, Left]
                 - InputAndLogs:
                     borders: [Top, Right, Bottom, Left]
@@ -110,7 +107,7 @@ general:
     - sorter: ByIRelativePath
       reverse: false
   prompt:
-    format: "> "
+    format: "❯ "
   cursor:
     format: █
   logs:
@@ -133,20 +130,13 @@ general:
           style:
             fg: null
             bg: null
-            add_modifier:
-              bits: 0
-            sub_modifier:
-              bits: 0
+            add_modifiers: null
+            sub_modifiers: null
         - format: '╭──── path'
         - format: size
         - format: type
       style:
-        fg: null
-        bg: null
-        add_modifier:
-          bits: 1
-        sub_modifier:
-          bits: 0
+        add_modifiers: [Bold]
       height: 1
     row:
       cols:
@@ -154,78 +144,35 @@ general:
         - format: >
             {{{tree}}}{{{prefix}}}{{{meta.icon}}}{{#if (ne meta.icon "")}} {{/if}}{{{relativePath}}}{{#if isDir}}/{{/if}}{{{suffix}}}
             {{#if isSymlink}}-> {{#if isBroken}}×{{else}}{{{symlink.absolutePath}}}{{/if}}{{#if symlink.isDir}}/{{/if}}{{/if}}
-          style:
-            fg: null
-            bg: null
-            add_modifier:
-              bits: 0
-            sub_modifier:
-              bits: 0
         - format: '{{#unless isDir}}{{humansize size}}{{/unless}}'
         - format: '{{#if isSymlink}}{{{symlink.mimeEssence}}}{{else}}{{{mimeEssence}}}{{/if}}'
-      style:
-        fg: null
-        bg: null
-        add_modifier:
-          bits: 0
-        sub_modifier:
-          bits: 0
       height: 0
-    style:
-      fg: null
-      bg: null
-      add_modifier:
-        bits: 0
-      sub_modifier:
-        bits: 0
     tree:
       - format: ├─
-        style:
-          fg: null
-          bg: null
-          add_modifier:
-            bits: 0
-          sub_modifier:
-            bits: 0
       - format: ├─
       - format: ╰─
-    col_spacing: 1
+    col_spacing: 0
     col_widths:
       - Percentage: 10
       - Percentage: 50
       - Percentage: 20
       - Percentage: 20
+
   default_ui:
     prefix: '  '
     suffix: ''
-    style:
-      fg: null
-      bg: null
-      add_modifier:
-        bits: 0
-      sub_modifier:
-        bits: 0
   focus_ui:
     prefix: ▸[
     suffix: ']'
     style:
       fg: Blue
-      bg: null
-      add_modifier:
-        bits: 1
-      sub_modifier:
-        bits: 0
+      add_modifiers: [Bold]
   selection_ui:
     prefix: ' {'
     suffix: '}'
     style:
       fg: LightGreen
-      bg: null
-      add_modifier:
-        bits: 1
-      sub_modifier:
-        bits: 0
-
+      add_modifiers: [Bold]
   sort_and_filter_ui:
     separator:
       format: " › "
@@ -359,31 +306,16 @@ node_types:
   directory:
     style:
       fg: Cyan
-      bg: null
-      add_modifier:
-        bits: 1
-      sub_modifier:
-        bits: 0
+      add_modifiers: [Bold]
     meta:
       icon: ð
   file:
-    style:
-      fg: null
-      bg: null
-      add_modifier:
-        bits: 0
-      sub_modifier:
-        bits: 0
     meta:
       icon: ƒ
   symlink:
     style:
       fg: Magenta
-      bg: null
-      add_modifier:
-        bits: 4
-      sub_modifier:
-        bits: 0
+      add_modifiers: [Italic]
     meta:
       icon: §
   mime_essence: {}

--- a/src/config.yml
+++ b/src/config.yml
@@ -19,17 +19,25 @@ layouts:
                   - Min: 1
                   - Length: 3
               splits:
-                - SortAndFilter
-                - Table
-                - InputAndLogs
+                - SortAndFilter:
+                    borders: [Top, Right, Bottom, Left]
+                - Table:
+                    title:
+                      style:
+                        fg: Red
+                    borders: [Top, Right, Bottom, Left]
+                - InputAndLogs:
+                    borders: [Top, Right, Bottom, Left]
           - Vertical:
               config:
                 constraints:
                   - Percentage: 50
                   - Percentage: 50
               splits:
-                - Selection
-                - HelpMenu
+                - Selection:
+                    borders: [Top, Right, Bottom, Left]
+                - HelpMenu:
+                    borders: [Top, Right, Bottom, Left]
     no_help:
       Horizontal:
         config:
@@ -44,10 +52,14 @@ layouts:
                   - Min: 1
                   - Length: 3
               splits:
-                - SortAndFilter
-                - Table
-                - InputAndLogs
-          - Selection
+                - SortAndFilter:
+                    borders: [Top, Right, Bottom, Left]
+                - Table:
+                    borders: [Top, Right, Bottom, Left]
+                - InputAndLogs:
+                    borders: [Top, Right, Bottom, Left]
+          - Selection:
+              borders: [Top, Right, Bottom, Left]
 
     no_selection:
       Horizontal:
@@ -63,10 +75,14 @@ layouts:
                   - Min: 1
                   - Length: 3
               splits:
-                - SortAndFilter
-                - Table
-                - InputAndLogs
-          - HelpMenu
+                - SortAndFilter:
+                    borders: [Top, Right, Bottom, Left]
+                - Table:
+                    borders: [Top, Right, Bottom, Left]
+                - InputAndLogs:
+                    borders: [Top, Right, Bottom, Left]
+          - HelpMenu:
+              borders: [Top, Right, Bottom, Left]
 
     no_help_no_selection:
       Vertical:
@@ -76,9 +92,12 @@ layouts:
             - Min: 1
             - Length: 3
         splits:
-          - SortAndFilter
-          - Table
-          - InputAndLogs
+          - SortAndFilter:
+              borders: [Top, Right, Bottom, Left]
+          - Table:
+              borders: [Top, Right, Bottom, Left]
+          - InputAndLogs:
+              borders: [Top, Right, Bottom, Left]
 
 general:
   show_hidden: false

--- a/src/config.yml
+++ b/src/config.yml
@@ -1,7 +1,89 @@
-version: v0.5.13
+version: v0.6.0
+layouts:
+  builtin:
+    default:
+      Horizontal:
+        config:
+          horizontal_margin: 0
+          vertical_margin: 0
+          constraints:
+            - Percentage: 70
+            - Percentage: 30
+        splits:
+          - Vertical:
+              config:
+                margin: 0
+                constraints:
+                  - Length: 3
+                  - Min: 1
+                  - Length: 3
+              splits:
+                - SortAndFilter
+                - Table
+                - InputAndLogs
+          - Vertical:
+              config:
+                constraints:
+                  - Percentage: 50
+                  - Percentage: 50
+              splits:
+                - Selection
+                - HelpMenu
+    no_help:
+      Horizontal:
+        config:
+          constraints:
+            - Percentage: 70
+            - Percentage: 30
+        splits:
+          - Vertical:
+              config:
+                constraints:
+                  - Length: 3
+                  - Min: 1
+                  - Length: 3
+              splits:
+                - SortAndFilter
+                - Table
+                - InputAndLogs
+          - Selection
+
+    no_selection:
+      Horizontal:
+        config:
+          constraints:
+            - Percentage: 70
+            - Percentage: 30
+        splits:
+          - Vertical:
+              config:
+                constraints:
+                  - Length: 3
+                  - Min: 1
+                  - Length: 3
+              splits:
+                - SortAndFilter
+                - Table
+                - InputAndLogs
+          - HelpMenu
+
+    no_help_no_selection:
+      Vertical:
+        config:
+          constraints:
+            - Length: 3
+            - Min: 1
+            - Length: 3
+        splits:
+          - SortAndFilter
+          - Table
+          - InputAndLogs
+
 general:
   show_hidden: false
   read_only: false
+  initial_layout: default
+  initial_mode: default
   initial_sorting:
     - sorter: ByCanonicalIsDir
       reverse: true
@@ -89,10 +171,10 @@ general:
       - format: ╰─
     col_spacing: 1
     col_widths:
-      - percentage: 10
-      - percentage: 50
-      - percentage: 20
-      - percentage: 20
+      - Percentage: 10
+      - Percentage: 50
+      - Percentage: 20
+      - Percentage: 20
   default_ui:
     prefix: '  '
     suffix: ''
@@ -823,6 +905,10 @@ modes:
               - SwitchModeBuiltin: search
               - SetInputBuffer: ''
               - Explore
+          ctrl-w:
+            help: switch layout
+            messages:
+              - SwitchModeBuiltin: switch_layout
           d:
             help: delete
             messages:
@@ -1095,7 +1181,7 @@ modes:
           s:
             help: selection operations
             messages:
-              - SwitchModeBuiltin: selection ops
+              - SwitchModeBuiltin: selection_ops
 
           l:
             help: logs
@@ -1191,5 +1277,39 @@ modes:
             - BufferInputFromKey
             - AddNodeFilterFromInput: IRelativePathDoesContain
             - Explore
+
+    switch_layout:
+      name: switch layout
+      help: null
+      extra_help: null
+      key_bindings:
+        on_key:
+          1:
+            help: default
+            messages:
+              - SwitchLayoutBuiltin: default
+              - SwitchMode: default
+          2:
+            help: no help menu
+            messages:
+              - SwitchLayoutBuiltin: no_help
+              - SwitchMode: default
+          3:
+            help: no selection panel
+            messages:
+              - SwitchLayoutBuiltin: no_selection
+              - SwitchMode: default
+          4:
+            help: no help or selection
+            messages:
+              - SwitchLayoutBuiltin: no_help_no_selection
+              - SwitchMode: default
+          ctrl-c:
+            help: terminate
+            messages:
+              - Terminate
+        default:
+          messages:
+            - SwitchMode: default
 
   custom: {}

--- a/src/config.yml
+++ b/src/config.yml
@@ -1,5 +1,6 @@
 version: v0.6.0
 layouts:
+  custom: {}
   builtin:
     default:
       Horizontal:

--- a/src/default_config.rs
+++ b/src/default_config.rs
@@ -11,6 +11,10 @@ pub fn version() -> String {
     DEFAULT_CONFIG.version().clone()
 }
 
+pub fn layouts() -> config::LayoutsConfig {
+    DEFAULT_CONFIG.layouts().clone()
+}
+
 pub fn general() -> config::GeneralConfig {
     DEFAULT_CONFIG.general().clone()
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -384,7 +384,7 @@ impl Key {
         matches!(self, Self::Special(_))
     }
 
-    pub fn to_char(&self) -> Option<char> {
+    pub fn to_char(self) -> Option<char> {
         match self {
             Self::Num0 => Some('0'),
             Self::Num1 => Some('1'),

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -556,9 +556,18 @@ pub fn draw_layout<B: Backend>(
                         .map(|c| (*c).into())
                         .collect::<Vec<TuiConstraint>>(),
                 )
-                .margin(config.margin().unwrap_or_default())
-                .horizontal_margin(config.horizontal_margin().unwrap_or_default())
-                .vertical_margin(config.vertical_margin().unwrap_or_default())
+                .horizontal_margin(
+                    config
+                        .horizontal_margin()
+                        .or_else(|| config.margin())
+                        .unwrap_or_default(),
+                )
+                .vertical_margin(
+                    config
+                        .vertical_margin()
+                        .or_else(|| config.margin())
+                        .unwrap_or_default(),
+                )
                 .split(rect);
             splits
                 .into_iter()
@@ -576,9 +585,18 @@ pub fn draw_layout<B: Backend>(
                         .map(|c| (*c).into())
                         .collect::<Vec<TuiConstraint>>(),
                 )
-                .margin(config.margin().unwrap_or_default())
-                .horizontal_margin(config.horizontal_margin().unwrap_or_default())
-                .vertical_margin(config.vertical_margin().unwrap_or_default())
+                .horizontal_margin(
+                    config
+                        .horizontal_margin()
+                        .or_else(|| config.margin())
+                        .unwrap_or_default(),
+                )
+                .vertical_margin(
+                    config
+                        .vertical_margin()
+                        .or_else(|| config.margin())
+                        .unwrap_or_default(),
+                )
                 .split(rect);
             splits
                 .into_iter()

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -534,6 +534,7 @@ pub fn draw_layout<B: Backend>(
     hb: &Handlebars,
 ) {
     match layout {
+        Layout::Nothing => {}
         Layout::Table => draw_table(f, rect, app, hb),
         Layout::SortAndFilter => draw_sort_n_filter(f, rect, app, hb),
         Layout::HelpMenu => draw_help_menu(f, rect, app, hb),


### PR DESCRIPTION
Now, users can change the UI layout via the `SwitchLayout{Builtin|Custom}`
message, or by using key `ctrl-w`.

There are 3 default layout options -

- default
- no_help
- no_selection
- no_help_no_selection

Also, the initial mode and the initial layout can be specified in the
config.

----------

Any layouts will default to `Nothing` which resembles blank screen.
However, they will be overwritten when there is a more specific layout
available either in the super config or in the sub config.

-----------------

- Define layout constraints based on screen size and relative panel
  size.
- Define borders.
- Define panel style.
- Define panel title and title style.

--------------

It's difficult to calculate the bits for adding and removing modifiers.
With this commit, we be will use words `Bold`, `Italic` instead of `bits:.

Closes: #107