### PR TITLE
Fix exploring and escaping paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1630,7 +1630,7 @@ dependencies = [
 
 [[package]]
 name = "xplr"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xplr"
-version = "0.7.2"  # Update config.yml, config.rs and default.nix
+version = "0.8.0"  # Update config.yml, config.rs
 authors = ["Arijit Basu <sayanarijit@gmail.com>"]
 edition = "2018"
 description = "A hackable, minimal, fast TUI file explorer"

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,14 +5,14 @@ use crate::app::NodeSorter;
 use crate::app::NodeSorterApplicable;
 use crate::default_config;
 use crate::ui::Border;
+use crate::ui::Constraint;
+use crate::ui::Layout;
 use crate::ui::Style;
 use anyhow::Result;
 use indexmap::IndexSet;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::collections::HashMap;
-use tui::layout::Constraint as TuiConstraint;
-use tui::layout::Rect;
 
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -247,60 +247,6 @@ impl TableRowConfig {
     /// Get a reference to the table row config's height.
     pub fn height(&self) -> Option<u16> {
         self.height
-    }
-}
-
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub enum Constraint {
-    Percentage(u16),
-    Ratio(u32, u32),
-    Length(u16),
-    LengthLessThanScreenHeight(u16),
-    LengthLessThanScreenWidth(u16),
-    LengthLessThanLayoutHeight(u16),
-    LengthLessThanLayoutWidth(u16),
-    Max(u16),
-    MaxLessThanScreenHeight(u16),
-    MaxLessThanScreenWidth(u16),
-    MaxLessThanLayoutHeight(u16),
-    MaxthLessThanLayoutWidth(u16),
-    Min(u16),
-    MinLessThanScreenHeight(u16),
-    MinLessThanScreenWidth(u16),
-    MinLessThanLayoutHeight(u16),
-    MinLessThanLayoutWidth(u16),
-}
-
-impl Constraint {
-    pub fn to_tui(self, screen_size: Rect, layout_size: Rect) -> TuiConstraint {
-        match self {
-            Self::Percentage(n) => TuiConstraint::Percentage(n),
-            Self::Ratio(x, y) => TuiConstraint::Ratio(x, y),
-            Self::Length(n) => TuiConstraint::Length(n),
-            Self::LengthLessThanScreenHeight(n) => {
-                TuiConstraint::Length(screen_size.height.max(n) - n)
-            }
-            Self::LengthLessThanScreenWidth(n) => {
-                TuiConstraint::Length(screen_size.width.max(n) - n)
-            }
-            Self::LengthLessThanLayoutHeight(n) => {
-                TuiConstraint::Length(layout_size.height.max(n) - n)
-            }
-            Self::LengthLessThanLayoutWidth(n) => {
-                TuiConstraint::Length(layout_size.width.max(n) - n)
-            }
-            Self::Max(n) => TuiConstraint::Max(n),
-            Self::MaxLessThanScreenHeight(n) => TuiConstraint::Max(screen_size.height.max(n) - n),
-            Self::MaxLessThanScreenWidth(n) => TuiConstraint::Max(screen_size.width.max(n) - n),
-            Self::MaxLessThanLayoutHeight(n) => TuiConstraint::Max(layout_size.height.max(n) - n),
-            Self::MaxthLessThanLayoutWidth(n) => TuiConstraint::Max(layout_size.width.max(n) - n),
-            Self::Min(n) => TuiConstraint::Min(n),
-            Self::MinLessThanScreenHeight(n) => TuiConstraint::Min(screen_size.height.max(n) - n),
-            Self::MinLessThanScreenWidth(n) => TuiConstraint::Min(screen_size.width.max(n) - n),
-            Self::MinLessThanLayoutHeight(n) => TuiConstraint::Min(layout_size.height.max(n) - n),
-            Self::MinLessThanLayoutWidth(n) => TuiConstraint::Min(layout_size.width.max(n) - n),
-        }
     }
 }
 
@@ -1067,6 +1013,11 @@ impl BuiltinModesConfig {
     pub fn sort(&self) -> &Mode {
         &self.sort
     }
+
+    /// Get a reference to the builtin modes config's switch layout.
+    pub fn switch_layout(&self) -> &Mode {
+        &self.switch_layout
+    }
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -1111,49 +1062,6 @@ impl ModesConfig {
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
-pub struct LayoutOptions {
-    #[serde(default)]
-    margin: Option<u16>,
-    #[serde(default)]
-    horizontal_margin: Option<u16>,
-    #[serde(default)]
-    vertical_margin: Option<u16>,
-    #[serde(default)]
-    constraints: Option<Vec<Constraint>>,
-}
-
-impl LayoutOptions {
-    pub fn extend(mut self, other: Self) -> Self {
-        self.margin = other.margin.or(self.margin);
-        self.horizontal_margin = other.horizontal_margin.or(self.horizontal_margin);
-        self.vertical_margin = other.vertical_margin.or(self.vertical_margin);
-        self.constraints = other.constraints.or(self.constraints);
-        self
-    }
-
-    /// Get a reference to the layout options's constraints.
-    pub fn constraints(&self) -> &Option<Vec<Constraint>> {
-        &self.constraints
-    }
-
-    /// Get a reference to the layout options's margin.
-    pub fn margin(&self) -> Option<u16> {
-        self.margin
-    }
-
-    /// Get a reference to the layout options's horizontal margin.
-    pub fn horizontal_margin(&self) -> Option<u16> {
-        self.horizontal_margin
-    }
-
-    /// Get a reference to the layout options's vertical margin.
-    pub fn vertical_margin(&self) -> Option<u16> {
-        self.vertical_margin
-    }
-}
-
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
 pub struct PanelUiConfig {
     #[serde(default)]
     title: UiElement,
@@ -1185,72 +1093,6 @@ impl PanelUiConfig {
     /// Get a reference to the block config's style.
     pub fn style(&self) -> &Style {
         &self.style
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub enum Layout {
-    Nothing(Option<PanelUiConfig>),
-    Table(Option<PanelUiConfig>),
-    InputAndLogs(Option<PanelUiConfig>),
-    Selection(Option<PanelUiConfig>),
-    HelpMenu(Option<PanelUiConfig>),
-    SortAndFilter(Option<PanelUiConfig>),
-    Horizontal {
-        config: LayoutOptions,
-        splits: Vec<Layout>,
-    },
-    Vertical {
-        config: LayoutOptions,
-        splits: Vec<Layout>,
-    },
-}
-
-impl Default for Layout {
-    fn default() -> Self {
-        Self::Nothing(Default::default())
-    }
-}
-
-impl Layout {
-    pub fn extend(self, other: Self) -> Self {
-        match (self, other) {
-            (s, Self::Nothing(_)) => s,
-            (Self::Table(s), Self::Table(o)) => Self::Table(o.or(s)),
-            (Self::InputAndLogs(s), Self::InputAndLogs(o)) => Self::InputAndLogs(o.or(s)),
-            (Self::Selection(s), Self::Selection(o)) => Self::Selection(o.or(s)),
-            (Self::HelpMenu(s), Self::HelpMenu(o)) => Self::HelpMenu(o.or(s)),
-            (Self::SortAndFilter(s), Self::SortAndFilter(o)) => Self::SortAndFilter(o.or(s)),
-            (
-                Self::Horizontal {
-                    config: sconfig,
-                    splits: _,
-                },
-                Self::Horizontal {
-                    config: oconfig,
-                    splits: osplits,
-                },
-            ) => Self::Horizontal {
-                config: sconfig.extend(oconfig),
-                splits: osplits,
-            },
-
-            (
-                Self::Vertical {
-                    config: sconfig,
-                    splits: _,
-                },
-                Self::Vertical {
-                    config: oconfig,
-                    splits: osplits,
-                },
-            ) => Self::Vertical {
-                config: sconfig.extend(oconfig),
-                splits: osplits,
-            },
-            (_, other) => other,
-        }
     }
 }
 
@@ -1394,9 +1236,7 @@ impl Config {
 
     pub fn is_compatible(&self) -> Result<bool> {
         let result = match self.parsed_version()? {
-            (0, 7, 2) => true,
-            (0, 7, 1) => true,
-            (0, 7, 0) => true,
+            (0, 8, 0) => true,
             (_, _, _) => false,
         };
 
@@ -1405,11 +1245,7 @@ impl Config {
 
     pub fn upgrade_notification(&self) -> Result<Option<&str>> {
         let result = match self.parsed_version()? {
-            (0, 7, 2) => None,
-            (0, 7, 1) => Some("App version updated. Fixed global help menu"),
-            (0, 7, 0) => {
-                Some("App version updated. Use `tab` to select files while in search mode")
-            }
+            (0, 8, 0) => None,
             (_, _, _) => None,
         };
 

--- a/src/config.yml
+++ b/src/config.yml
@@ -1,4 +1,4 @@
-version: v0.7.2
+version: v0.8.0
 layouts:
   custom: {}
   builtin:
@@ -332,13 +332,12 @@ modes:
               - BashExec: |
                   (while IFS= read -r line; do
                     if cp -vr -- "${line:?}" ./; then
-                      echo "LogSuccess: $line copied to $PWD" >> "${XPLR_PIPE_MSG_IN:?}"
+                      echo LogSuccess: $line copied to $PWD >> "${XPLR_PIPE_MSG_IN:?}"
                     else
-                      echo "LogError: Failed to copy $line to $PWD" >> "${XPLR_PIPE_MSG_IN:?}"
+                      echo LogError: Failed to copy $line to $PWD >> "${XPLR_PIPE_MSG_IN:?}"
                     fi
                   done < "${XPLR_PIPE_SELECTION_OUT:?}")
-                  echo Explore >> "${XPLR_PIPE_MSG_IN:?}"
-                  echo ClearSelection >> "${XPLR_PIPE_MSG_IN:?}"
+                  echo ExplorePwd >> "${XPLR_PIPE_MSG_IN:?}"
                   read -p "[enter to continue]"
               - SwitchModeBuiltin: default
 
@@ -348,12 +347,12 @@ modes:
               - BashExec: |
                   (while IFS= read -r line; do
                     if mv -v -- "${line:?}" ./; then
-                      echo "LogSuccess: $line moved to $PWD" >> "${XPLR_PIPE_MSG_IN:?}"
+                      echo LogSuccess: $line moved to $PWD >> "${XPLR_PIPE_MSG_IN:?}"
                     else
-                      echo "LogError: Failed to move $line to $PWD" >> "${XPLR_PIPE_MSG_IN:?}"
+                      echo LogError: Failed to move $line to $PWD >> "${XPLR_PIPE_MSG_IN:?}"
                     fi
                   done < "${XPLR_PIPE_SELECTION_OUT:?}")
-                  echo Explore >> "${XPLR_PIPE_MSG_IN:?}"
+                  echo ExplorePwd >> "${XPLR_PIPE_MSG_IN:?}"
                   read -p "[enter to continue]"
               - SwitchModeBuiltin: default
 
@@ -378,14 +377,10 @@ modes:
             messages:
               - BashExecSilently: |
                   PTH="${XPLR_INPUT_BUFFER:?}"
-                  if touch -- "${PTH:?}"; then
-                    echo Explore >> "${XPLR_PIPE_MSG_IN:?}"
-                    echo "LogSuccess: $PTH created" >> "${XPLR_PIPE_MSG_IN:?}"
-                    echo "FocusPath: $PTH" >> "${XPLR_PIPE_MSG_IN:?}"
-                  else
-                    echo "LogError: Failed to create $PTH" >> "${XPLR_PIPE_MSG_IN:?}"
-                    echo Refresh >> "${XPLR_PIPE_MSG_IN:?}"
-                  fi
+                  touch -- "${PTH:?}" \
+                    && echo LogSuccess: $PTH created >> "${XPLR_PIPE_MSG_IN:?}" \
+                    && echo ExplorePwd >> "${XPLR_PIPE_MSG_IN:?}" \
+                    && echo FocusByFileName: "'"$PTH"'" >> "${XPLR_PIPE_MSG_IN:?}"
               - SwitchModeBuiltin: default
           backspace:
             help: remove last character
@@ -423,14 +418,10 @@ modes:
             messages:
               - BashExecSilently: |
                   PTH="${XPLR_INPUT_BUFFER:?}"
-                  if mkdir -p -- "${PTH:?}"; then
-                    echo Explore >> "${XPLR_PIPE_MSG_IN:?}"
-                    echo "LogSuccess: $PTH created" >> "${XPLR_PIPE_MSG_IN:?}"
-                    echo "FocusPath: $PTH" >> "${XPLR_PIPE_MSG_IN:?}"
-                  else
-                    echo "LogError: Failed to create $PTH" >> "${XPLR_PIPE_MSG_IN:?}"
-                    echo Refresh >> "${XPLR_PIPE_MSG_IN:?}"
-                  fi
+                  mkdir -p -- "${PTH:?}" \
+                    && echo ExplorePwd >> "${XPLR_PIPE_MSG_IN:?}" \
+                    && echo LogSuccess: $PTH created >> "${XPLR_PIPE_MSG_IN:?}" \
+                    && echo FocusByFileName: "'"$PTH"'" >> "${XPLR_PIPE_MSG_IN:?}"
               - SwitchModeBuiltin: default
 
           backspace:
@@ -507,13 +498,10 @@ modes:
               - BashExecSilently: |
                   SRC="${XPLR_FOCUS_PATH:?}"
                   TARGET="${XPLR_INPUT_BUFFER:?}"
-                  if mv -v -- "${SRC:?}" "${TARGET:?}"; then
-                    echo Explore >> "${XPLR_PIPE_MSG_IN:?}"
-                    echo "LogSuccess: $SRC renamed to $TARGET" >> "${XPLR_PIPE_MSG_IN:?}"
-                    echo "FocusPath: $TARGET" >> "${XPLR_PIPE_MSG_IN:?}"
-                  else
-                    echo "LogError: Failed to rename $SRC to $TARGET" >> "${XPLR_PIPE_MSG_IN:?}"
-                  fi
+                  mv -v -- "${SRC:?}" "${TARGET:?}" \
+                    && echo ExplorePwd >> "${XPLR_PIPE_MSG_IN:?}" \
+                    && echo FocusByFileName: "'"$TARGET"'" >> "${XPLR_PIPE_MSG_IN:?}" \
+                    && echo LogSuccess: $SRC renamed to $TARGET >> "${XPLR_PIPE_MSG_IN:?}"
               - SwitchModeBuiltin: default
 
           backspace:
@@ -555,21 +543,21 @@ modes:
               - RemoveNodeFilterFromInput: IRelativePathDoesNotContain
               - RemoveInputBufferLastCharacter
               - AddNodeFilterFromInput: IRelativePathDoesNotContain
-              - Explore
+              - ExplorePwd
           ctrl-w:
             help: remove last word
             messages:
               - RemoveNodeFilterFromInput: IRelativePathDoesNotContain
               - RemoveInputBufferLastWord
               - AddNodeFilterFromInput: IRelativePathDoesNotContain
-              - Explore
+              - ExplorePwd
           ctrl-u:
             help: remove line
             messages:
               - RemoveNodeFilterFromInput: IRelativePathDoesNotContain
               - SetInputBuffer: ""
               - AddNodeFilterFromInput: IRelativePathDoesNotContain
-              - Explore
+              - ExplorePwd
           enter:
             help: apply filter
             messages:
@@ -579,7 +567,7 @@ modes:
             messages:
               - RemoveNodeFilterFromInput: IRelativePathDoesNotContain
               - SwitchModeBuiltin: default
-              - Explore
+              - ExplorePwd
           ctrl-c:
             help: terminate
             messages:
@@ -589,7 +577,7 @@ modes:
             - RemoveNodeFilterFromInput: IRelativePathDoesNotContain
             - BufferInputFromKey
             - AddNodeFilterFromInput: IRelativePathDoesNotContain
-            - Explore
+            - ExplorePwd
 
     relative_path_does_contain:
       name: relative path does contain
@@ -601,21 +589,21 @@ modes:
               - RemoveNodeFilterFromInput: IRelativePathDoesContain
               - RemoveInputBufferLastCharacter
               - AddNodeFilterFromInput: IRelativePathDoesContain
-              - Explore
+              - ExplorePwd
           ctrl-w:
             help: remove last word
             messages:
               - RemoveNodeFilterFromInput: IRelativePathDoesContain
               - RemoveInputBufferLastWord
               - AddNodeFilterFromInput: IRelativePathDoesContain
-              - Explore
+              - ExplorePwd
           ctrl-u:
             help: remove line
             messages:
               - RemoveNodeFilterFromInput: IRelativePathDoesContain
               - SetInputBuffer: ""
               - AddNodeFilterFromInput: IRelativePathDoesContain
-              - Explore
+              - ExplorePwd
           enter:
             help: apply filter
             messages:
@@ -625,7 +613,7 @@ modes:
             messages:
               - RemoveNodeFilterFromInput: IRelativePathDoesContain
               - SwitchModeBuiltin: default
-              - Explore
+              - ExplorePwd
           ctrl-c:
             help: terminate
             messages:
@@ -636,7 +624,7 @@ modes:
             - RemoveNodeFilterFromInput: IRelativePathDoesContain
             - BufferInputFromKey
             - AddNodeFilterFromInput: IRelativePathDoesContain
-            - Explore
+            - ExplorePwd
 
     filter:
       name: filter
@@ -646,31 +634,31 @@ modes:
             help: remove last filter
             messages:
               - RemoveLastNodeFilter
-              - Explore
+              - ExplorePwd
           r:
             help: relative does contain
             messages:
               - SwitchModeBuiltin: relative_path_does_contain
               - SetInputBuffer: ""
               - AddNodeFilterFromInput: IRelativePathDoesContain
-              - Explore
+              - ExplorePwd
           R:
             help: relative does not contain
             messages:
               - SwitchModeBuiltin: relative_path_does_not_contain
               - SetInputBuffer: ""
               - AddNodeFilterFromInput: IRelativePathDoesNotContain
-              - Explore
+              - ExplorePwd
           ctrl-r:
             help: reset filters
             messages:
               - ResetNodeFilters
-              - Explore
+              - ExplorePwd
           ctrl-u:
             help: clear filters
             messages:
               - ClearNodeFilters
-              - Explore
+              - ExplorePwd
           ctrl-c:
             help: terminate
             messages:
@@ -690,49 +678,49 @@ modes:
             help: remove last sorter
             messages:
               - RemoveLastNodeSorter
-              - Explore
+              - ExplorePwd
           '!':
             help: reverse sorters
             messages:
               - ReverseNodeSorters
-              - Explore
+              - ExplorePwd
           ctrl-r:
             help: reset sorters
             messages:
               - ResetNodeSorters
-              - Explore
+              - ExplorePwd
           ctrl-u:
             help: clear sorters
             messages:
               - ClearNodeSorters
-              - Explore
+              - ExplorePwd
           r:
             help: by relative path
             messages:
               - AddNodeSorter:
                   sorter: ByIRelativePath
-              - Explore
+              - ExplorePwd
           R:
             help: by relative path reverse
             messages:
               - AddNodeSorter:
                   sorter: ByIRelativePath
                   reverse: true
-              - Explore
+              - ExplorePwd
 
           e:
             help: by canonical extension
             messages:
               - AddNodeSorter:
                   sorter: ByCanonicalExtension
-              - Explore
+              - ExplorePwd
           E:
             help: by canonical extension reverse
             messages:
               - AddNodeSorter:
                   sorter: ByCanonicalExtension
                   reverse: true
-              - Explore
+              - ExplorePwd
           n:
             help: by node type
             messages:
@@ -742,7 +730,7 @@ modes:
                   sorter: ByCanonicalIsFile
               - AddNodeSorter:
                   sorter: ByIsSymlink
-              - Explore
+              - ExplorePwd
           N:
             help: by node type reverse
             messages:
@@ -755,33 +743,33 @@ modes:
               - AddNodeSorter:
                   sorter: ByIsSymlink
                   reverse: true
-              - Explore
+              - ExplorePwd
           m:
             help: by canonical mime essence
             messages:
               - AddNodeSorter:
                   sorter: ByCanonicalMimeEssence
-              - Explore
+              - ExplorePwd
           M:
             help: by canonical mime essence reverse
             messages:
               - AddNodeSorter:
                   sorter: ByCanonicalMimeEssence
                   reverse: true
-              - Explore
+              - ExplorePwd
           s:
             help: by size
             messages:
               - AddNodeSorter:
                   sorter: BySize
-              - Explore
+              - ExplorePwd
           S:
             help: by size reverse
             messages:
               - AddNodeSorter:
                   sorter: BySize
                   reverse: true
-              - Explore
+              - ExplorePwd
           ctrl-c:
             help: terminate
             messages:
@@ -823,7 +811,7 @@ modes:
               - ToggleNodeFilter:
                   filter: RelativePathDoesNotStartWith
                   input: .
-              - Explore
+              - ExplorePwd
           ':':
             help: action
             messages:
@@ -837,7 +825,7 @@ modes:
             help: go home
             messages:
               - BashExecSilently: |
-                  echo "ChangeDirectory: ${HOME:?}" >> "${XPLR_PIPE_MSG_IN:?}"
+                  echo ChangeDirectory: "'"${HOME:?}"'" >> "${XPLR_PIPE_MSG_IN:?}"
           G:
             help: go to bottom
             messages:
@@ -851,7 +839,7 @@ modes:
             messages:
               - SwitchModeBuiltin: search
               - SetInputBuffer: ''
-              - Explore
+              - ExplorePwd
           ctrl-w:
             help: switch layout
             messages:
@@ -881,7 +869,7 @@ modes:
             messages:
               - SwitchModeBuiltin: rename
               - BashExecSilently: |
-                  echo "SetInputBuffer: $(basename ${XPLR_FOCUS_PATH})" >> "${XPLR_PIPE_MSG_IN:?}"
+                  echo SetInputBuffer: "'"$(basename "${XPLR_FOCUS_PATH}")"'" >> "${XPLR_PIPE_MSG_IN:?}"
           right:
             help: enter
             messages:
@@ -969,7 +957,9 @@ modes:
                       exit 1
                     fi
                   fi
-                  $OPENER "${XPLR_FOCUS_PATH:?}" &> /dev/null &
+                  (while IFS= read -r line; do
+                    $OPENER "${line:?}" &> /dev/null &
+                   done < "${XPLR_PIPE_RESULT_OUT:?}")
               - SwitchModeBuiltin: default
               - ClearScreen
               - Refresh
@@ -1046,20 +1036,20 @@ modes:
                   (while IFS= read -r line; do
                     if [ -d "$line" ]; then
                       if rmdir -v -- "${line:?}"; then
-                        echo "LogSuccess: $line deleted" >> "${XPLR_PIPE_MSG_IN:?}"
+                        echo LogSuccess: $line deleted >> "${XPLR_PIPE_MSG_IN:?}"
+                        echo FocusNext >> "${XPLR_PIPE_MSG_IN:?}"
                       else
-                        echo "LogError: Failed to delete $line" >> "${XPLR_PIPE_MSG_IN:?}"
+                        echo LogError: Failed to delete $line >> "${XPLR_PIPE_MSG_IN:?}"
                       fi
                     else
                       if rm -v -- "${line:?}"; then
-                        echo "FocusNext" >> "${XPLR_PIPE_MSG_IN:?}"
-                        echo "LogSuccess: $line deleted" >> "${XPLR_PIPE_MSG_IN:?}"
+                        echo LogSuccess: $line deleted >> "${XPLR_PIPE_MSG_IN:?}"
                       else
-                        echo "LogError: Failed to delete $line" >> "${XPLR_PIPE_MSG_IN:?}"
+                        echo LogError: Failed to delete $line >> "${XPLR_PIPE_MSG_IN:?}"
                       fi
                     fi
                   done < "${XPLR_PIPE_RESULT_OUT:?}")
-                  echo Explore >> "${XPLR_PIPE_MSG_IN:?}"
+                  echo ExplorePwdAsync >> "${XPLR_PIPE_MSG_IN:?}"
                   read -p "[enter to continue]"
               - SwitchModeBuiltin: default
 
@@ -1069,16 +1059,16 @@ modes:
               - BashExec: |
                   (while IFS= read -r line; do
                     if rm -rfv -- "${line:?}"; then
-                      echo "FocusNext" >> "${XPLR_PIPE_MSG_IN:?}"
-                      echo "LogSuccess: $line deleted" >> "${XPLR_PIPE_MSG_IN:?}"
+                      echo LogSuccess: $line deleted >> "${XPLR_PIPE_MSG_IN:?}"
+                      echo FocusNext >> "${XPLR_PIPE_MSG_IN:?}"
                     else
-                      echo "LogError: Failed to delete $line" >> "${XPLR_PIPE_MSG_IN:?}"
+                      echo LogError: Failed to delete $line >> "${XPLR_PIPE_MSG_IN:?}"
                     fi
                   done < "${XPLR_PIPE_RESULT_OUT:?}")
-                  echo Explore >> "${XPLR_PIPE_MSG_IN:?}"
+                  echo ExplorePwd >> "${XPLR_PIPE_MSG_IN:?}"
                   read -p "[enter to continue]"
               - SwitchModeBuiltin: default
-              - Explore
+              - ExplorePwd
 
           ctrl-c:
             help: terminate
@@ -1110,7 +1100,7 @@ modes:
                   command: bash
                   args:
                     - "-i"
-              - Explore
+              - ExplorePwd
               - SwitchModeBuiltin: default
 
           c:
@@ -1122,7 +1112,9 @@ modes:
             help: open in editor
             messages:
               - BashExec: |
-                  ${EDITOR:-vi} -- "${XPLR_FOCUS_PATH:?}"
+                  (while IFS= read -r line; do
+                    ${EDITOR:-vi} "${line:?}"
+                   done < "${XPLR_PIPE_RESULT_OUT:?}")
               - SwitchModeBuiltin: default
 
           s:
@@ -1165,21 +1157,21 @@ modes:
               - RemoveNodeFilterFromInput: IRelativePathDoesContain
               - RemoveInputBufferLastCharacter
               - AddNodeFilterFromInput: IRelativePathDoesContain
-              - Explore
+              - ExplorePwd
           ctrl-w:
             help: remove last word
             messages:
               - RemoveNodeFilterFromInput: IRelativePathDoesContain
               - RemoveInputBufferLastWord
               - AddNodeFilterFromInput: IRelativePathDoesContain
-              - Explore
+              - ExplorePwd
           ctrl-u:
             help: remove line
             messages:
               - RemoveNodeFilterFromInput: IRelativePathDoesContain
               - SetInputBuffer: ""
               - AddNodeFilterFromInput: IRelativePathDoesContain
-              - Explore
+              - ExplorePwd
           ctrl-c:
             help: terminate
             messages:
@@ -1193,27 +1185,27 @@ modes:
             messages:
               - RemoveNodeFilterFromInput: IRelativePathDoesContain
               - SwitchModeBuiltin: default
-              - Explore
+              - ExplorePwd
           esc:
             help: cancel
             messages:
               - RemoveNodeFilterFromInput: IRelativePathDoesContain
               - SwitchModeBuiltin: default
-              - Explore
+              - ExplorePwd
           left:
             help: back
             messages:
               - RemoveNodeFilterFromInput: IRelativePathDoesContain
               - Back
               - SetInputBuffer: ''
-              - Explore
+              - ExplorePwd
           right:
             help: enter
             messages:
               - RemoveNodeFilterFromInput: IRelativePathDoesContain
               - Enter
               - SetInputBuffer: ''
-              - Explore
+              - ExplorePwd
           up:
             help: up
             messages:
@@ -1227,7 +1219,7 @@ modes:
             - RemoveNodeFilterFromInput: IRelativePathDoesContain
             - BufferInputFromKey
             - AddNodeFilterFromInput: IRelativePathDoesContain
-            - Explore
+            - ExplorePwd
 
     switch_layout:
       name: switch layout

--- a/src/explorer.rs
+++ b/src/explorer.rs
@@ -1,54 +1,58 @@
 use crate::app::{DirectoryBuffer, ExplorerConfig, ExternalMsg, InternalMsg, MsgIn, Node, Task};
+use anyhow::Result;
 use std::fs;
 use std::path::PathBuf;
 use std::sync::mpsc::Sender;
 use std::thread;
 
-pub fn explore(
+pub fn explore_sync(
+    config: ExplorerConfig,
+    parent: String,
+    focused_path: Option<String>,
+) -> Result<DirectoryBuffer> {
+    let path = PathBuf::from(&parent);
+
+    let dirs = fs::read_dir(&path)?;
+    let mut nodes = dirs
+        .filter_map(|d| {
+            d.ok().map(|e| {
+                e.path()
+                    .file_name()
+                    .map(|n| n.to_string_lossy().to_string())
+                    .unwrap_or_default()
+            })
+        })
+        .map(|name| Node::new(parent.clone(), name))
+        .filter(|n| config.filter(n))
+        .collect::<Vec<Node>>();
+
+    nodes.sort_by(|a, b| config.sort(a, b));
+
+    let focus_index = if let Some(focus) = focused_path {
+        nodes
+            .iter()
+            .enumerate()
+            .find(|(_, n)| n.relative_path() == &focus)
+            .map(|(i, _)| i)
+            .unwrap_or(0)
+    } else {
+        0
+    };
+
+    Ok(DirectoryBuffer::new(parent, nodes, focus_index))
+}
+
+pub fn explore_async(
     config: ExplorerConfig,
     parent: String,
     focused_path: Option<String>,
     tx: Sender<Task>,
 ) {
-    let path = PathBuf::from(&parent);
-    let path_cloned = path.clone();
-    let tx_cloned = tx.clone();
-    let config_cloned = config.clone();
-
     thread::spawn(move || {
-        fs::read_dir(&path)
-            .map(|dirs| {
-                let mut nodes = dirs
-                    .filter_map(|d| {
-                        d.ok().map(|e| {
-                            e.path()
-                                .file_name()
-                                .map(|n| n.to_string_lossy().to_string())
-                                .unwrap_or_default()
-                        })
-                    })
-                    .map(|name| Node::new(parent.clone(), name))
-                    .filter(|n| config.filter(n))
-                    .collect::<Vec<Node>>();
-                nodes.sort_by(|a, b| config.sort(a, b));
-                nodes
-            })
-            .map(|nodes| {
-                let focus_index = if let Some(focus) = focused_path {
-                    nodes
-                        .iter()
-                        .enumerate()
-                        .find(|(_, n)| n.relative_path() == &focus)
-                        .map(|(i, _)| i)
-                        .unwrap_or(0)
-                } else {
-                    0
-                };
-
-                let dir = DirectoryBuffer::new(parent.clone(), nodes, focus_index);
-
+        explore_sync(config, parent.clone(), focused_path)
+            .map(|dirbuf| {
                 tx.send(Task::new(
-                    MsgIn::Internal(InternalMsg::AddDirectory(parent, dir)),
+                    MsgIn::Internal(InternalMsg::AddDirectory(parent, dirbuf)),
                     None,
                 ))
                 .unwrap_or_default();
@@ -61,15 +65,22 @@ pub fn explore(
                 .unwrap_or_default();
             })
     });
+}
 
-    if let Some(grand_parent) = path_cloned.parent() {
-        explore(
-            config_cloned,
+pub fn explore_recursive_async(
+    config: ExplorerConfig,
+    parent: String,
+    focused_path: Option<String>,
+    tx: Sender<Task>,
+) {
+    let path = PathBuf::from(&parent);
+    explore_async(config.clone(), parent, focused_path, tx.clone());
+    if let Some(grand_parent) = path.parent() {
+        explore_recursive_async(
+            config,
             grand_parent.to_string_lossy().to_string(),
-            path_cloned
-                .file_name()
-                .map(|f| f.to_string_lossy().to_string()),
-            tx_cloned,
+            path.file_name().map(|f| f.to_string_lossy().to_string()),
+            tx,
         );
     }
 }

--- a/src/pwd_watcher.rs
+++ b/src/pwd_watcher.rs
@@ -42,7 +42,7 @@ pub fn keep_watching(
         }
 
         if rx.try_recv().is_ok() {
-            let msg = MsgIn::External(ExternalMsg::Explore);
+            let msg = MsgIn::External(ExternalMsg::ExplorePwdAsync);
             tx_msg_in.send(Task::new(msg, None)).unwrap_or_default();
         } else {
             thread::sleep(Duration::from_secs(1));


### PR DESCRIPTION
This PR targets 2 pain points.

1. The `Explore` message was async, which caused some unexpected
   behavior. This was fixed by splitting `Explore` into `ExplorePwd`,
   `ExplorePwdAsync` and `ExploreParentsAsync`. `ExploreParentsAsync`
   is similar to the former `Explore`, which is mainly used when loading
   `xplr` for the first time. However, what we'll be using frequently
   are `ExplorePwd` and `ExplorePwdAsync` messages.

2. Files with spaces caused some unexpected behavior. This was fixed by
   escaping the paths properly. This also fixed focusing of a file after
   creating or renaming it.

Anothor breaking change is that `XPLR_PIPE_FOCUS_OUT` has been removed.
`XPLR_FOCUS_PATH` is all we need. So, the rule of thumb is if a variable
contains one liner value, it can be used directly from the env vars.
Variables that can contain multi-line values, will be exposed via the
pipes.

Minor changes are

- Add `switch_mode` mode to the global key binding help menu
- Moved some UI related code from config.rs to ui.rs.
- Fixed compilation issue on `rustc 1.50.0`.