### PR TITLE
Optimize performance

### DIFF
--- a/src/explorer.rs
+++ b/src/explorer.rs
@@ -46,23 +46,29 @@ pub fn explore_async(
     config: ExplorerConfig,
     parent: String,
     focused_path: Option<String>,
-    tx: Sender<Task>,
+    tx_msg_in: Sender<Task>,
+    tx_pwd_watcher: Sender<String>,
 ) {
     thread::spawn(move || {
         explore_sync(config, parent.clone(), focused_path)
-            .map(|dirbuf| {
-                tx.send(Task::new(
-                    MsgIn::Internal(InternalMsg::AddDirectory(parent, dirbuf)),
-                    None,
-                ))
-                .unwrap_or_default();
+            .map(|buf| {
+                tx_pwd_watcher
+                    .send(buf.parent().clone())
+                    .unwrap_or_default();
+                tx_msg_in
+                    .send(Task::new(
+                        MsgIn::Internal(InternalMsg::AddDirectory(parent.clone(), buf)),
+                        None,
+                    ))
+                    .unwrap_or_default();
             })
             .unwrap_or_else(|e| {
-                tx.send(Task::new(
-                    MsgIn::External(ExternalMsg::LogError(e.to_string())),
-                    None,
-                ))
-                .unwrap_or_default();
+                tx_msg_in
+                    .send(Task::new(
+                        MsgIn::External(ExternalMsg::LogError(e.to_string())),
+                        None,
+                    ))
+                    .unwrap_or_default();
             })
     });
 }
@@ -71,16 +77,24 @@ pub fn explore_recursive_async(
     config: ExplorerConfig,
     parent: String,
     focused_path: Option<String>,
-    tx: Sender<Task>,
+    tx_msg_in: Sender<Task>,
+    tx_pwd_watcher: Sender<String>,
 ) {
     let path = PathBuf::from(&parent);
-    explore_async(config.clone(), parent, focused_path, tx.clone());
+    explore_async(
+        config.clone(),
+        parent,
+        focused_path,
+        tx_msg_in.clone(),
+        tx_pwd_watcher.clone(),
+    );
     if let Some(grand_parent) = path.parent() {
         explore_recursive_async(
             config,
             grand_parent.to_string_lossy().to_string(),
             path.file_name().map(|f| f.to_string_lossy().to_string()),
-            tx,
+            tx_msg_in,
+            tx_pwd_watcher,
         );
     }
 }


### PR DESCRIPTION
```
Benchmarking focus next item: Collecting 100 samples in estimated 5.1972 s (126k itera                                                                                      focus next item         time:   [41.216 us 41.346 us 41.494 us]
                        change: [-28.669% -28.110% -27.551%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  4 (4.00%) high mild
  5 (5.00%) high severe

Benchmarking focus previous item: Collecting 100 samples in estimated 5.0576 s (116k i                                                                                      focus previous item     time:   [43.589 us 43.754 us 43.927 us]
                        change: [-29.506% -28.748% -28.039%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) high mild
  2 (2.00%) high severe

Benchmarking focus first item: Collecting 100 samples in estimated 5.1765 s (116k iter                                                                                      focus first item        time:   [44.071 us 44.340 us 44.634 us]
                        change: [-26.739% -26.314% -25.885%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  8 (8.00%) high mild
  4 (4.00%) high severe

Benchmarking focus last item: Collecting 100 samples in estimated 5.1522 s (116k itera                                                                                      focus last item         time:   [43.950 us 44.214 us 44.541 us]
                        change: [-27.571% -26.953% -26.337%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  5 (5.00%) high mild
  6 (6.00%) high severe

Benchmarking leave and enter directory: Collecting 100 samples in estimated 5.4863 s (                                                                                      leave and enter directory
                        time:   [96.645 us 96.915 us 97.234 us]
                        change: [-28.720% -27.224% -25.666%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  6 (6.00%) high mild
  3 (3.00%) high severe
```