### PR TITLE
Further optimize performance and CPU usage

### DIFF
--- a/src/event_reader.rs
+++ b/src/event_reader.rs
@@ -14,7 +14,8 @@ pub fn keep_reading(tx_msg_in: Sender<Task>, rx_event_reader: Receiver<bool>) {
                 is_paused = paused;
             };
 
-            if !is_paused && event::poll(std::time::Duration::from_millis(1)).unwrap_or_default() {
+            if !is_paused && event::poll(std::time::Duration::from_millis(200)).unwrap_or_default()
+            {
                 match event::read() {
                     Ok(Event::Key(key)) => {
                         let key = Key::from_event(key);


### PR DESCRIPTION
- Optimize by avoiding cloning the whole app in each iteration of the main
loop.
- Increase the input poll timeout from 1 to 200. This works because the
poll will not apply to key hold.
- Do not read input pipe if it hasn't been modified.