### PR TITLE
Add support for un-mapping keys.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1193,7 +1193,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "xplr"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xplr"
-version = "0.9.0"  # Update config.yml, config.rs
+version = "0.9.1"  # Update config.yml, config.rs
 authors = ["Arijit Basu <sayanarijit@gmail.com>"]
 edition = "2018"
 description = "A hackable, minimal, fast TUI file explorer"

--- a/src/app.rs
+++ b/src/app.rs
@@ -1686,10 +1686,9 @@ impl App {
         let key_str = key.to_string();
         let default = kb.default().clone();
         let msgs = kb
-            .remaps()
+            .on_key()
             .get(&key_str)
-            .and_then(|k| kb.on_key().get(k))
-            .or_else(|| kb.on_key().get(&key_str))
+            .to_owned()
             .map(|a| Some(a.messages().clone()))
             .unwrap_or_else(|| {
                 if key.is_alphabet() {
@@ -2522,7 +2521,7 @@ impl App {
                             .key_bindings()
                             .remaps()
                             .iter()
-                            .filter(|(_, t)| t == &k)
+                            .filter(|(_, maybeto)| maybeto.as_ref().map(|to| to == k).unwrap_or(false))
                             .map(|(f, _)| f.clone())
                             .collect::<Vec<String>>()
                             .join(", ");

--- a/src/config.yml
+++ b/src/config.yml
@@ -1,4 +1,4 @@
-version: v0.9.0
+version: v0.9.1
 layouts:
   custom: {}
   builtin:
@@ -139,7 +139,7 @@ general:
       - format: ├─
       - format: ├─
       - format: ╰─
-    col_spacing: 0
+    col_spacing: 1
     col_widths:
       - Percentage: 10
       - Percentage: 50
@@ -359,6 +359,26 @@ modes:
                   done < "${XPLR_PIPE_SELECTION_OUT:?}")
                   echo ExplorePwdAsync >> "${XPLR_PIPE_MSG_IN:?}"
                   read -p "[enter to continue]"
+              - PopMode
+              - Refresh
+          x:
+            help: open in gui
+            messages:
+              - BashExecSilently: |
+                  if [ -z "$OPENER" ]; then
+                    if command -v xdg-open; then
+                      OPENER=xdg-open
+                    elif command -v open; then
+                      OPENER=open
+                    else
+                      echo 'LogError: $OPENER not found' >> "${XPLR_PIPE_MSG_IN:?}"
+                      exit 1
+                    fi
+                  fi
+                  (while IFS= read -r line; do
+                    $OPENER "${line:?}" > /dev/null 2>&1
+                   done < "${XPLR_PIPE_RESULT_OUT:?}")
+              - ClearScreen
               - PopMode
               - Refresh
           ctrl-c:
@@ -841,7 +861,8 @@ modes:
             help: global help menu
             messages:
               - BashExec: |
-                  cat -- "${XPLR_PIPE_GLOBAL_HELP_MENU_OUT}" | ${PAGER:-less}
+                  [ -z "$PAGER" ] && PAGER="less -+F"
+                  cat -- "${XPLR_PIPE_GLOBAL_HELP_MENU_OUT}" | ${PAGER:?}
           '~':
             help: go home
             messages:
@@ -866,6 +887,7 @@ modes:
             help: switch layout
             messages:
               - SwitchModeBuiltin: switch_layout
+              - Refresh
           d:
             help: delete
             messages:
@@ -884,7 +906,7 @@ modes:
             help: go to
             messages:
               - PopMode
-              - SwitchModeBuiltin: go to
+              - SwitchModeBuiltin: go_to
               - Refresh
           left:
             help: back
@@ -999,9 +1021,7 @@ modes:
                       exit 1
                     fi
                   fi
-                  (while IFS= read -r line; do
-                    $OPENER "${line:?}" &> /dev/null &
-                   done < "${XPLR_PIPE_RESULT_OUT:?}")
+                  $OPENER "${XPLR_FOCUS_PATH:?}" > /dev/null 2>&1
               - ClearScreen
               - PopMode
               - Refresh
@@ -1167,7 +1187,8 @@ modes:
             help: logs
             messages:
               - BashExec: |
-                  cat -- "${XPLR_PIPE_LOGS_OUT}" | ${PAGER:-less}
+                  [ -z "$PAGER" ] && PAGER="less -+F"
+                  cat -- "${XPLR_PIPE_LOGS_OUT}" | ${PAGER:?}
               - PopMode
               - Refresh
           ctrl-c:

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -659,7 +659,7 @@ fn draw_help_menu<B: Backend>(
                     .key_bindings()
                     .remaps()
                     .iter()
-                    .filter(|(_, t)| t == &&k)
+                    .filter(|(_, maybeto)| maybeto.as_ref().map(|to| to == &k).unwrap_or(false))
                     .map(|(f, _)| f.clone())
                     .collect::<Vec<String>>()
                     .join("|");


### PR DESCRIPTION
Use `remaps: {key: null}` to un-map a key.

Also,
- `gx` will now open only the file under focus.
- `:sx` will open the selected files.

And other minor improvements.