### PR TITLE
Read input pipe only once when commands execute

### DIFF
--- a/src/pipe_reader.rs
+++ b/src/pipe_reader.rs
@@ -1,66 +1,104 @@
 use crate::app::{ExternalMsg, MsgIn, Task};
+use anyhow::Result;
 use std::fs;
 use std::io::prelude::*;
-use std::path::PathBuf;
 use std::sync::mpsc::Sender;
-use std::thread;
-use std::time::Duration;
 
-pub fn keep_reading(pipe: String, tx: Sender<Task>) {
-    let mut last_modified = None;
-    thread::spawn(move || loop {
-        let path = PathBuf::from(&pipe);
-
-        if !path.exists() {
-            thread::sleep(Duration::from_millis(50));
-            continue;
-        }
-
-        let modified = path.metadata().and_then(|m| m.modified()).ok();
-
-        if modified == last_modified {
-            thread::sleep(Duration::from_millis(50));
-        } else if let Ok(mut file) = fs::OpenOptions::new()
-            .read(true)
-            .write(true)
-            .create(false)
-            .open(&pipe)
-        {
+pub fn read_all(pipe: &str, tx: Sender<Task>) -> Result<()> {
+    match fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(false)
+        .open(&pipe)
+    {
+        Ok(mut file) => {
             let mut in_str = String::new();
-            file.read_to_string(&mut in_str).unwrap_or_default();
-            file.set_len(0).unwrap_or_default();
+            file.read_to_string(&mut in_str)?;
+            file.set_len(0)?;
 
             if !in_str.is_empty() {
                 let msgs = in_str
                     .lines()
                     .map(|s| serde_yaml::from_str::<ExternalMsg>(s.trim()));
 
-                msgs.for_each(|msg| match msg {
-                    Ok(m) => {
-                        tx.send(Task::new(MsgIn::External(m), None))
-                            .unwrap_or_default();
-                    }
-                    Err(e) => {
-                        tx.send(Task::new(
+                for msg in msgs {
+                    match msg {
+                        Ok(m) => {
+                            tx.send(Task::new(MsgIn::External(m), None))?;
+                        }
+                        Err(e) => tx.send(Task::new(
                             MsgIn::External(ExternalMsg::LogError(e.to_string())),
                             None,
-                        ))
-                        .unwrap_or_default();
+                        ))?,
                     }
-                });
-            };
-        } else {
-            tx.send(Task::new(
-                MsgIn::External(ExternalMsg::LogError(format!(
-                    "Failed to open input pipe: {}",
-                    &pipe
-                ))),
-                None,
-            ))
-            .unwrap_or_default();
-            thread::sleep(Duration::from_secs(3));
+                }
+            }
         }
-
-        last_modified = modified;
-    });
+        Err(err) => {
+            tx.send(Task::new(
+                MsgIn::External(ExternalMsg::LogError(err.to_string())),
+                None,
+            ))?;
+        }
+    };
+    Ok(())
 }
+
+// pub fn keep_reading(pipe: String, tx: Sender<Task>) {
+//     let mut last_modified = None;
+//     thread::spawn(move || loop {
+//         let path = PathBuf::from(&pipe);
+
+//         if !path.exists() {
+//             thread::sleep(Duration::from_millis(50));
+//             continue;
+//         }
+
+//         let modified = path.metadata().and_then(|m| m.modified()).ok();
+
+//         if modified == last_modified {
+//             thread::sleep(Duration::from_millis(50));
+//         } else if let Ok(mut file) = fs::OpenOptions::new()
+//             .read(true)
+//             .write(true)
+//             .create(false)
+//             .open(&pipe)
+//         {
+//             let mut in_str = String::new();
+//             file.read_to_string(&mut in_str).unwrap_or_default();
+//             file.set_len(0).unwrap_or_default();
+
+//             if !in_str.is_empty() {
+//                 let msgs = in_str
+//                     .lines()
+//                     .map(|s| serde_yaml::from_str::<ExternalMsg>(s.trim()));
+
+//                 msgs.for_each(|msg| match msg {
+//                     Ok(m) => {
+//                         tx.send(Task::new(MsgIn::External(m), None))
+//                             .unwrap_or_default();
+//                     }
+//                     Err(e) => {
+//                         tx.send(Task::new(
+//                             MsgIn::External(ExternalMsg::LogError(e.to_string())),
+//                             None,
+//                         ))
+//                         .unwrap_or_default();
+//                     }
+//                 });
+//             };
+//         } else {
+//             tx.send(Task::new(
+//                 MsgIn::External(ExternalMsg::LogError(format!(
+//                     "Failed to open input pipe: {}",
+//                     &pipe
+//                 ))),
+//                 None,
+//             ))
+//             .unwrap_or_default();
+//             thread::sleep(Duration::from_secs(3));
+//         }
+
+//         last_modified = modified;
+//     });
+// }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -102,9 +102,9 @@ pub fn run(
 
     // Threads
     auto_refresher::start_auto_refreshing(tx_msg_in.clone());
-    pipe_reader::keep_reading(app.pipe().msg_in().clone(), tx_msg_in.clone());
     event_reader::keep_reading(tx_msg_in.clone(), rx_event_reader);
     pwd_watcher::keep_watching(app.pwd(), tx_msg_in.clone(), rx_pwd_watcher)?;
+    // pipe_reader::keep_reading(app.pipe().msg_in().clone(), tx_msg_in.clone());
 
     'outer: for task in rx_msg_in {
         match app.handle_task(task) {
@@ -182,6 +182,8 @@ pub fn run(
                                     }
                                 })
                                 .unwrap_or_else(|e| Err(e.to_string()));
+
+                            pipe_reader::read_all(app.pipe().msg_in(), tx_msg_in.clone())?;
                             app.cleanup_pipes()?;
 
                             if let Err(e) = status {
@@ -212,6 +214,8 @@ pub fn run(
                                     }
                                 })
                                 .unwrap_or_else(|e| Err(e.to_string()));
+
+                            pipe_reader::read_all(app.pipe().msg_in(), tx_msg_in.clone())?;
                             app.cleanup_pipes()?;
 
                             if let Err(e) = status {


### PR DESCRIPTION
The initial idea was to enable other tools to control `xplr` via the
input pipe. However, so far I didn't feel the need to use this feature.
And even if there is any need, it's much better to implement ad-hoc
services instead of wasting cpu resources.