### PR TITLE
Add CallLua and CallLuaSilently

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1099,7 +1099,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "xplr"
-version = "0.10.0-beta.5"
+version = "0.10.0-beta.6"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xplr"
-version = "0.10.0-beta.5"  # Update lua.rs
+version = "0.10.0-beta.6"  # Update lua.rs
 authors = ["Arijit Basu <sayanarijit@gmail.com>"]
 edition = "2018"
 description = "A hackable, minimal, fast TUI file explorer"

--- a/src/app.rs
+++ b/src/app.rs
@@ -1130,6 +1130,17 @@ pub enum ExternalMsg {
     /// **Example:** `CallSilently: {command: tput, args: ["bell"]}`
     CallSilently(Command),
 
+    /// Call a Lua function
+    ///
+    /// **Example:** `CallLua: custom.foo_funtion`
+    CallLua(String),
+
+    /// Like `CallLua` but without the flicker. The stdin, stdout
+    /// stderr will be piped to null. So it's non-interactive.
+    ///
+    /// **Example:** `CallLuaSilently: custom.bar_function`
+    CallLuaSilently(String),
+
     /// An alias to `Call: {command: bash, args: ["-c", "${command}"], silent: false}`
     /// where ${command} is the given value.
     ///
@@ -1329,6 +1340,8 @@ pub enum MsgOut {
     Debug(String),
     Call(Command),
     CallSilently(Command),
+    CallLua(String),
+    CallLuaSilently(String),
     Enque(Task),
 }
 
@@ -1635,6 +1648,8 @@ impl App {
                 ExternalMsg::SwitchLayoutCustom(mode) => self.switch_layout_custom(&mode),
                 ExternalMsg::Call(cmd) => self.call(cmd),
                 ExternalMsg::CallSilently(cmd) => self.call_silently(cmd),
+                ExternalMsg::CallLua(func) => self.call_lua(func),
+                ExternalMsg::CallLuaSilently(func) => self.call_lua_silently(func),
                 ExternalMsg::BashExec(cmd) => self.bash_exec(cmd),
                 ExternalMsg::BashExecSilently(cmd) => self.bash_exec_silently(cmd),
                 ExternalMsg::Select => self.select(),
@@ -2158,6 +2173,18 @@ impl App {
     fn call_silently(mut self, command: Command) -> Result<Self> {
         self.logs_hidden = true;
         self.msg_out.push_back(MsgOut::CallSilently(command));
+        Ok(self)
+    }
+
+    fn call_lua(mut self, func: String) -> Result<Self> {
+        self.logs_hidden = true;
+        self.msg_out.push_back(MsgOut::CallLua(func));
+        Ok(self)
+    }
+
+    fn call_lua_silently(mut self, func: String) -> Result<Self> {
+        self.logs_hidden = true;
+        self.msg_out.push_back(MsgOut::CallLuaSilently(func));
         Ok(self)
     }
 

--- a/src/init.lua
+++ b/src/init.lua
@@ -2062,7 +2062,3 @@ xplr.fn.builtin.fmt_general_table_row_cols_3 = function(m)
     return m.mime_essence
   end
 end
-
-xplr.fn.custom.foo = function(a, b)
-  return a + b
-end

--- a/src/lua.rs
+++ b/src/lua.rs
@@ -1,3 +1,5 @@
+use crate::app::App;
+use crate::app::ExternalMsg;
 use crate::app::VERSION;
 use crate::config::Config;
 use anyhow::bail;
@@ -113,6 +115,15 @@ pub fn extend(lua: &Lua, path: &str) -> Result<Config> {
     Ok(config)
 }
 
+/// Used to extend Lua globals
+pub fn call(lua: &Lua, func: &str, args: &App) -> Result<Vec<ExternalMsg>> {
+    let func = resolve_fn(&lua.globals(), func)?;
+    let args = lua.to_value(args)?;
+    let msgs: mlua::Value = func.call((args,))?;
+    let msgs: Vec<ExternalMsg> = lua.from_value(msgs)?;
+    Ok(msgs)
+}
+
 #[cfg(test)]
 mod test {
 
@@ -121,12 +132,12 @@ mod test {
     #[test]
     fn test_compatibility() {
         assert!(check_version(VERSION, "foo path").is_ok());
-        assert!(check_version("0.10.0-beta.5", "foo path").is_ok());
+        assert!(check_version("0.10.0-beta.6", "foo path").is_ok());
 
         assert!(check_version("0.9.0", "foo path").is_err());
         assert!(check_version("0.10.0", "foo path").is_err());
-        assert!(check_version("0.10.0-beta.4", "foo path").is_err());
-        assert!(check_version("0.10.0-beta.6", "foo path").is_err());
-        assert!(check_version("1.10.0-beta.5", "foo path").is_err());
+        assert!(check_version("0.10.0-beta.5", "foo path").is_err());
+        assert!(check_version("0.10.0-beta.7", "foo path").is_err());
+        assert!(check_version("1.10.0-beta.6", "foo path").is_err());
     }
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -225,7 +225,20 @@ pub fn run(
                                 })
                                 .unwrap_or_else(|e| Err(e.to_string()));
 
-                            pipe_reader::read_all(app.pipe().msg_in(), tx_msg_in.clone())?;
+                            match pipe_reader::read_all(app.pipe().msg_in()) {
+                                Ok(msgs) => {
+                                    for msg in msgs {
+                                        app = app.handle_task(app::Task::new(
+                                            app::MsgIn::External(msg),
+                                            None,
+                                        ))?;
+                                    }
+                                }
+                                Err(err) => {
+                                    app = app.log_error(err.to_string())?;
+                                }
+                            };
+
                             app.cleanup_pipes()?;
 
                             if let Err(e) = status {
@@ -291,7 +304,20 @@ pub fn run(
                                 })
                                 .unwrap_or_else(|e| Err(e.to_string()));
 
-                            pipe_reader::read_all(app.pipe().msg_in(), tx_msg_in.clone())?;
+                            match pipe_reader::read_all(app.pipe().msg_in()) {
+                                Ok(msgs) => {
+                                    for msg in msgs {
+                                        app = app.handle_task(app::Task::new(
+                                            app::MsgIn::External(msg),
+                                            None,
+                                        ))?;
+                                    }
+                                }
+                                Err(err) => {
+                                    app = app.log_error(err.to_string())?;
+                                }
+                            };
+
                             app.cleanup_pipes()?;
 
                             if let Err(e) = status {


### PR DESCRIPTION
This works:

```lua
xplr.fn.custom.ping = function(app)
  print("What's your name?")
  local name = io.read()
  os.execute('read -p "Hello ' .. name .. ', you are in ' .. app.pwd .. '"')
  return {
    { LogSuccess = "pong" },
  }
end
```

Then it can be called via `CallLua: custom.ping`.