### PR TITLE
Fix "ctrl-i" key for history navigation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1108,7 +1108,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "xplr"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xplr"
-version = "0.11.0"  # Update lua.rs
+version = "0.11.1"  # Update lua.rs
 authors = ["Arijit Basu <sayanarijit@gmail.com>"]
 edition = "2018"
 description = "A hackable, minimal, fast TUI file explorer"

--- a/src/init.lua
+++ b/src/init.lua
@@ -745,6 +745,7 @@ xplr.config.modes.builtin.default = {
   }
 }
 
+xplr.config.modes.builtin.default.key_bindings.on_key["tab"] = xplr.config.modes.builtin.default.key_bindings.on_key["ctrl-i"]
 xplr.config.modes.builtin.default.key_bindings.on_key["v"] = xplr.config.modes.builtin.default.key_bindings.on_key.space
 xplr.config.modes.builtin.default.key_bindings.on_key["V"] = xplr.config.modes.builtin.default.key_bindings.on_key["ctrl-a"]
 xplr.config.modes.builtin.default.key_bindings.on_key["/"] = xplr.config.modes.builtin.default.key_bindings.on_key["ctrl-f"]

--- a/src/lua.rs
+++ b/src/lua.rs
@@ -134,9 +134,10 @@ mod test {
     fn test_compatibility() {
         assert!(check_version(VERSION, "foo path").is_ok());
         assert!(check_version("0.11.0", "foo path").is_ok());
+        assert!(check_version("0.11.1", "foo path").is_ok());
 
-        assert!(check_version("0.11.1", "foo path").is_err());
-        assert!(check_version("0.10.0", "foo path").is_err());
-        assert!(check_version("1.12.0", "foo path").is_err());
+        assert!(check_version("0.11.2", "foo path").is_err());
+        assert!(check_version("0.10.1", "foo path").is_err());
+        assert!(check_version("1.12.1", "foo path").is_err());
     }
 }


### PR DESCRIPTION
Unfortunately, "ctrl-i" doesn't work unless "tab" i sremapped to the
key.