### PR TITLE
Optimize rendering speed by serializing less

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1108,7 +1108,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "xplr"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xplr"
-version = "0.13.0"  # Update lua.rs
+version = "0.13.1"  # Update lua.rs
 authors = ["Arijit Basu <sayanarijit@gmail.com>"]
 edition = "2018"
 description = "A hackable, minimal, fast TUI file explorer"

--- a/src/lua.rs
+++ b/src/lua.rs
@@ -5,7 +5,6 @@ use anyhow::Result;
 use mlua::Lua;
 use mlua::LuaSerdeExt;
 use serde::Deserialize;
-use serde::Serialize;
 use std::fs;
 
 const DEFAULT_LUA_SCRIPT: &str = include_str!("init.lua");
@@ -113,13 +112,12 @@ pub fn extend(lua: &Lua, path: &str) -> Result<Config> {
 }
 
 /// Used to call lua functions.
-pub fn call<'lua, A: Serialize, R: Deserialize<'lua>>(
+pub fn call<'lua, R: Deserialize<'lua>>(
     lua: &'lua Lua,
     func: &str,
-    args: &A,
+    args: mlua::Value<'lua>,
 ) -> Result<R> {
     let func = resolve_fn(&lua.globals(), func)?;
-    let args = lua.to_value(args)?;
     let res: mlua::Value = func.call(args)?;
     let res: R = lua.from_value(res)?;
     Ok(res)
@@ -134,10 +132,11 @@ mod test {
     fn test_compatibility() {
         assert!(check_version(VERSION, "foo path").is_ok());
         assert!(check_version("0.13.0", "foo path").is_ok());
+        assert!(check_version("0.13.1", "foo path").is_ok());
 
-        assert!(check_version("0.13.1", "foo path").is_err());
-        assert!(check_version("0.14.0", "foo path").is_err());
-        assert!(check_version("0.11.0", "foo path").is_err());
-        assert!(check_version("1.13.0", "foo path").is_err());
+        assert!(check_version("0.13.2", "foo path").is_err());
+        assert!(check_version("0.14.1", "foo path").is_err());
+        assert!(check_version("0.11.1", "foo path").is_err());
+        assert!(check_version("1.13.1", "foo path").is_err());
     }
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -12,6 +12,7 @@ use anyhow::Result;
 use crossterm::event;
 use crossterm::execute;
 use crossterm::terminal as term;
+use mlua::LuaSerdeExt;
 use std::fs;
 use std::io;
 use std::io::prelude::*;
@@ -39,7 +40,9 @@ fn call_lua(
         (get_tty()?.into(), get_tty()?.into(), get_tty()?.into())
     };
 
-    lua::call(lua, func, &app.to_lua_arg())
+    let arg = app.to_lua_arg();
+    let arg = lua.to_value(&arg)?;
+    lua::call(lua, func, arg)
 }
 
 fn call(app: &app::App, cmd: app::Command, silent: bool) -> io::Result<ExitStatus> {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -563,7 +563,7 @@ fn draw_table<B: Backend>(
                                 .iter()
                                 .filter_map(|c| {
                                     c.format().as_ref().map(|f| {
-                                        let out: Result<String> = lua::call(lua, f, &v);
+                                        let out: Result<String> = lua::call(lua, f, v.clone());
                                         match out {
                                             Ok(o) => ansi_to_text(o.bytes())
                                                 .unwrap_or_else(|e| Text::raw(format!("{:?}", e))),


### PR DESCRIPTION
Serializing to and from Lua value is expensive. Hence, once serialized,
we should reuse the value.