### PR TITLE
Disable mouse by default and bind `:m` to toggle

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -437,10 +437,13 @@ impl PanelUi {
 #[serde(deny_unknown_fields)]
 pub struct GeneralConfig {
     #[serde(default)]
-    pub show_hidden: Option<bool>,
+    pub enable_mouse: bool,
 
     #[serde(default)]
-    pub read_only: Option<bool>,
+    pub show_hidden: bool,
+
+    #[serde(default)]
+    pub read_only: bool,
 
     #[serde(default)]
     pub cursor: UiElement,
@@ -481,12 +484,12 @@ pub struct GeneralConfig {
 
 impl GeneralConfig {
     /// Get a reference to the general config's show hidden.
-    pub fn show_hidden(&self) -> Option<bool> {
+    pub fn show_hidden(&self) -> bool {
         self.show_hidden
     }
 
     /// Get a reference to the general config's read only.
-    pub fn read_only(&self) -> Option<bool> {
+    pub fn read_only(&self) -> bool {
         self.read_only
     }
 
@@ -548,6 +551,11 @@ impl GeneralConfig {
     /// Get a reference to the general config's panel ui.
     pub fn panel_ui(&self) -> &PanelUi {
         &self.panel_ui
+    }
+
+    /// Get a reference to the general config's enable mouse.
+    pub fn enable_mouse(&self) -> bool {
+        self.enable_mouse
     }
 }
 

--- a/src/init.lua
+++ b/src/init.lua
@@ -1334,6 +1334,13 @@ xplr.config.modes.builtin.action = {
           },
         }
       },
+      ["m"] = {
+        help = "toggle mouse",
+        messages = {
+          "PopMode",
+          "ToggleMouse",
+        }
+      },
       ["q"] = {
         help = "quit",
         messages = {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -28,7 +28,7 @@ lazy_static! {
 }
 
 fn read_only_indicator(app: &app::App) -> &str {
-    if app.config().general().read_only().unwrap_or_default() {
+    if app.config().general().read_only() {
         "(r)"
     } else {
         ""


### PR DESCRIPTION
- Make mouse disabled by default.
- Add key binding `:m` to toggle mouse.

Closes: https://github.com/sayanarijit/xplr/issues/206