### PR TITLE
Remove --locked

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           command: build
           toolchain: ${{ matrix.rust }}
-          args: --locked --release --target ${{ matrix.target }}
+          args: --release --target ${{ matrix.target }}
 
       - name: Install gpg secret key
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1048,7 +1048,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "xplr"
-version = "0.13.5"
+version = "0.13.6"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xplr"
-version = "0.13.5"  # Update lua.rs
+version = "0.13.6"  # Update lua.rs
 authors = ["Arijit Basu <sayanarijit@gmail.com>"]
 edition = "2018"
 description = "A hackable, minimal, fast TUI file explorer"

--- a/src/lua.rs
+++ b/src/lua.rs
@@ -137,10 +137,11 @@ mod test {
         assert!(check_version("0.13.3", "foo path").is_ok());
         assert!(check_version("0.13.4", "foo path").is_ok());
         assert!(check_version("0.13.5", "foo path").is_ok());
+        assert!(check_version("0.13.6", "foo path").is_ok());
 
-        assert!(check_version("0.13.6", "foo path").is_err());
-        assert!(check_version("0.14.5", "foo path").is_err());
-        assert!(check_version("0.11.5", "foo path").is_err());
-        assert!(check_version("1.13.5", "foo path").is_err());
+        assert!(check_version("0.13.7", "foo path").is_err());
+        assert!(check_version("0.14.6", "foo path").is_err());
+        assert!(check_version("0.11.6", "foo path").is_err());
+        assert!(check_version("1.13.6", "foo path").is_err());
     }
 }


### PR DESCRIPTION
Many crates are outdated. One is even yanked. IMO failing build is
better than running with insecure/bad dependencies.

Ref: https://github.com/sayanarijit/xplr/issues/212#issuecomment-855175144