### PR TITLE
Add support for fifo based previewer

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1272,6 +1272,17 @@ pub enum ExternalMsg {
     /// Toggle mouse
     ToggleMouse,
 
+    /// Start piping the focused path to the given fifo path
+    ///
+    /// **Example:** `StartFifo: /tmp/xplr.fifo`
+    StartFifo(String),
+
+    /// Close the active fifo and stop piping.
+    StopFifo,
+
+    /// Toggle betwen {Start|Stop}Fifo
+    ToggleFifo(String),
+
     /// Log information message.
     ///
     /// **Example:** `LogInfo: launching satellite`
@@ -1363,6 +1374,9 @@ pub enum MsgOut {
     EnableMouse,
     DisableMouse,
     ToggleMouse,
+    StartFifo(String),
+    StopFifo,
+    ToggleFifo(String),
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
@@ -1720,6 +1734,9 @@ impl App {
                 ExternalMsg::EnableMouse => self.enable_mouse(),
                 ExternalMsg::DisableMouse => self.disable_mouse(),
                 ExternalMsg::ToggleMouse => self.toggle_mouse(),
+                ExternalMsg::StartFifo(f) => self.start_fifo(f),
+                ExternalMsg::StopFifo => self.stop_fifo(),
+                ExternalMsg::ToggleFifo(f) => self.toggle_fifo(f),
                 ExternalMsg::LogInfo(l) => self.log_info(l),
                 ExternalMsg::LogSuccess(l) => self.log_success(l),
                 ExternalMsg::LogWarning(l) => self.log_warning(l),
@@ -2447,6 +2464,21 @@ impl App {
 
     fn toggle_mouse(mut self) -> Result<Self> {
         self.msg_out.push_back(MsgOut::ToggleMouse);
+        Ok(self)
+    }
+
+    fn start_fifo(mut self, path: String) -> Result<Self> {
+        self.msg_out.push_back(MsgOut::StartFifo(path));
+        Ok(self)
+    }
+
+    fn stop_fifo(mut self) -> Result<Self> {
+        self.msg_out.push_back(MsgOut::StopFifo);
+        Ok(self)
+    }
+
+    fn toggle_fifo(mut self, path: String) -> Result<Self> {
+        self.msg_out.push_back(MsgOut::ToggleFifo(path));
         Ok(self)
     }
 


### PR DESCRIPTION
Adds basic support for nnn-like FIFO based previewer.

The FIFO can be manager with the following messages:

- StartFifo: /path/to/fifo
- StopFifo
- ToggleFifo: /path/to/fifo

A basic nnn plugin wrapper example:

```lua
-- nnn_preview_wrapper.lua

-- Usage Example:
--
--   require("nnn_preview_wrapper").setup{
--     plugin_path = os.getenv("HOME") .. "/.config/nnn/plugins/preview-tabbed",
--     fifo_path = "/tmp/xplr.fifo",
--     mode = "action",
--     key = "p",
--   }
--
-- Press `:p` to toggle preview mode.

local function setup(o)

  if o.fifo_path == nil then
    o.fifo_path = os.getenv("NNN_FIFO")
  end

  if o.mode == nil then
    o.mode = "action"
  end

  if o.key == nil then
    o.key = "p"
  end

  local enabled = false
  local message = nil

  os.execute('[ ! -p "' .. o.fifo_path ..'" ] && mkfifo "' .. o.fifo_path .. '"')

  xplr.fn.custom.preview_toggle = function(app)

    if enabled then
      enabled = false
      message = "StopFifo"
    else
      os.execute('NNN_FIFO="' .. o.fifo_path .. '" "'.. o.plugin_path .. '" & ')
      enabled = true
      message = { StartFifo = o.fifo_path }
    end

    return { message }
  end

  xplr.config.modes.builtin[o.mode].key_bindings.on_key[o.key] = {
    help = "search with preview",
    messages = {
      "PopMode",
      { CallLuaSilently = "custom.preview_toggle" },
    },
  }
end

return { setup = setup }
```

Press `:p` to toggle preview mode.

Closes: https://github.com/sayanarijit/xplr/issues/205