### PR TITLE
Further improve the API.

### DIFF
--- a/examples/run.rs
+++ b/examples/run.rs
@@ -1,6 +1,5 @@
 fn main() {
-    let pwd = std::path::PathBuf::from("/");
-    match xplr::run(pwd, None, None) {
+    match xplr::runner(None).and_then(|a| a.run()) {
         Ok(Some(out)) => print!("{}", out),
         Ok(None) => {}
         Err(err) => {

--- a/src/app.rs
+++ b/src/app.rs
@@ -4,7 +4,7 @@ use crate::explorer;
 use crate::input::Key;
 use crate::lua;
 use crate::permissions::Permissions;
-use crate::runner;
+use crate::runner::Runner;
 use crate::ui::Layout;
 use anyhow::{bail, Result};
 use chrono::{DateTime, Local};
@@ -1595,6 +1595,8 @@ impl App {
             last_modes: Default::default(),
         };
 
+        fs::create_dir_all(app.session_path())?;
+
         if let Some(err) = load_err {
             app.log_error(err)
         } else {
@@ -2796,24 +2798,8 @@ impl App {
             last_modes: self.last_modes.clone(),
         }
     }
-
-    pub fn run(self, focused_path: Option<PathBuf>, lua: &mlua::Lua) -> Result<Option<String>> {
-        runner::run(self, focused_path, lua)
-    }
 }
 
-/// Run xplr TUI
-pub fn run(
-    pwd: PathBuf,
-    focused_path: Option<PathBuf>,
-    on_load: Option<Vec<ExternalMsg>>,
-) -> Result<Option<String>> {
-    let lua = mlua::Lua::new();
-    let mut app = App::create(pwd, &lua)?;
-    if let Some(msgs) = on_load {
-        for msg in msgs {
-            app = app.enqueue(Task::new(MsgIn::External(msg), None));
-        }
-    }
-    app.run(focused_path, &lua)
+pub fn runner(path: Option<PathBuf>) -> Result<Runner> {
+    Runner::new(path)
 }

--- a/src/bin/xplr.rs
+++ b/src/bin/xplr.rs
@@ -108,17 +108,10 @@ fn main() {
     } else if cli.version {
         println!("xplr {}", xplr::app::VERSION);
     } else {
-        let mut pwd = PathBuf::from(cli.path.unwrap_or_else(|| ".".into()))
-            .canonicalize()
-            .unwrap_or_default();
-        let mut focused_path = None;
-
-        if pwd.is_file() {
-            focused_path = pwd.file_name().map(|p| p.into());
-            pwd = pwd.parent().map(|p| p.into()).unwrap_or_else(|| ".".into());
-        }
-
-        match app::run(pwd, focused_path, Some(cli.on_load)) {
+        match app::runner(cli.path.as_ref().map(PathBuf::from))
+            .map(|a| a.with_on_load(cli.on_load))
+            .and_then(|a| a.run())
+        {
             Ok(Some(out)) => print!("{}", out),
             Ok(None) => {}
             Err(err) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,4 +15,4 @@ pub mod pwd_watcher;
 pub mod runner;
 pub mod ui;
 
-pub use app::run;
+pub use app::runner;


### PR DESCRIPTION
This improves the compatibility and adds the ability to introduce
non-breaking changes by using a builder pattern.

Example:

```rust
fn main() {
    match xplr::runner(None).and_then(|a| a.run()) {
        Ok(Some(out)) => print!("{}", out),
        Ok(None) => {}
        Err(err) => {
            if !err.to_string().is_empty() {
                eprintln!("error: {}", err);
            };

            std::process::exit(1);
        }
    }
}
```