### PR TITLE
Fix config path on macOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1115,7 +1115,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "xplr"
-version = "0.13.7"
+version = "0.14.0"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xplr"
-version = "0.13.7"  # Update lua.rs
+version = "0.14.0"  # Update lua.rs
 authors = ["Arijit Basu <sayanarijit@gmail.com>"]
 edition = "2018"
 description = "A hackable, minimal, fast TUI file explorer"

--- a/benches/criterion.rs
+++ b/benches/criterion.rs
@@ -18,7 +18,7 @@ fn navigation_benchmark(c: &mut Criterion) {
     });
 
     let lua = mlua::Lua::new();
-    let mut app = app::App::create(PWD.into(), &lua).expect("failed to create app");
+    let mut app = app::App::create(PWD.into(), &lua, None).expect("failed to create app");
 
     app = app
         .clone()
@@ -96,7 +96,7 @@ fn draw_benchmark(c: &mut Criterion) {
     });
 
     let lua = mlua::Lua::new();
-    let mut app = app::App::create(PWD.into(), &lua).expect("failed to create app");
+    let mut app = app::App::create(PWD.into(), &lua, None).expect("failed to create app");
 
     app = app
         .clone()

--- a/src/lua.rs
+++ b/src/lua.rs
@@ -131,18 +131,24 @@ mod test {
     #[test]
     fn test_compatibility() {
         assert!(check_version(VERSION, "foo path").is_ok());
-        assert!(check_version("0.13.0", "foo path").is_ok());
-        assert!(check_version("0.13.1", "foo path").is_ok());
-        assert!(check_version("0.13.2", "foo path").is_ok());
-        assert!(check_version("0.13.3", "foo path").is_ok());
-        assert!(check_version("0.13.4", "foo path").is_ok());
-        assert!(check_version("0.13.5", "foo path").is_ok());
-        assert!(check_version("0.13.6", "foo path").is_ok());
-        assert!(check_version("0.13.7", "foo path").is_ok());
 
-        assert!(check_version("0.13.8", "foo path").is_err());
-        assert!(check_version("0.14.7", "foo path").is_err());
-        assert!(check_version("0.11.7", "foo path").is_err());
-        assert!(check_version("1.13.7", "foo path").is_err());
+        // Current release if OK
+        assert!(check_version("0.14.0", "foo path").is_ok());
+
+        // Prev major release is ERR
+
+        // Prev minor release is ERR (Change when we get to v1)
+        assert!(check_version("0.13.0", "foo path").is_err());
+
+        // Prev bugfix release is OK
+
+        // Next major release is ERR
+        assert!(check_version("1.14.0", "foo path").is_err());
+
+        // Next minor release is ERR
+        assert!(check_version("0.15.0", "foo path").is_err());
+
+        // Next bugfix release is ERR (Change when we get to v1)
+        assert!(check_version("0.14.1", "foo path").is_err());
     }
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -90,6 +90,7 @@ fn call(app: &app::App, cmd: app::Command, silent: bool) -> io::Result<ExitStatu
 pub struct Runner {
     pwd: PathBuf,
     focused_path: Option<PathBuf>,
+    config: Option<PathBuf>,
     on_load: Vec<app::ExternalMsg>,
 }
 
@@ -106,6 +107,7 @@ impl Runner {
         Ok(Self {
             pwd,
             focused_path,
+            config: None,
             on_load: Default::default(),
         })
     }
@@ -115,9 +117,14 @@ impl Runner {
         self
     }
 
+    pub fn with_config(mut self, config: Option<PathBuf>) -> Self {
+        self.config = config;
+        self
+    }
+
     pub fn run(self) -> Result<Option<String>> {
         let lua = mlua::Lua::new();
-        let mut app = app::App::create(self.pwd, &lua)?;
+        let mut app = app::App::create(self.pwd, &lua, self.config)?;
 
         fs::create_dir_all(app.session_path())?;
 


### PR DESCRIPTION
Also, add `-c` / `--config` CLI option to specify custom config file.

Priority is:

`-c <PATH>` > `~/.config/xplr/init.lua` > `/etc/xplr/init.lua`.

Fixes: https://github.com/sayanarijit/xplr/issues/230