### PR TITLE
Add more quit options

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1306,7 +1306,16 @@ pub enum ExternalMsg {
     /// Quit with returncode zero (success).
     Quit,
 
-    /// Print selected paths if it's not empty, else, print the focused node's path.
+    /// Print $PWD and quit.
+    PrintPwdAndQuit,
+
+    /// Print the path under focus and quit. It can be empty string if there's nothing to focus.
+    PrintFocusPathAndQuit,
+
+    /// Print the selected paths and quit. It can be empty is no path is selected.
+    PrintSelectionAndQuit,
+
+    /// Print the selected paths if it's not empty, else, print the focused node's path.
     PrintResultAndQuit,
 
     /// Print the state of application in YAML format. Helpful for debugging or generating
@@ -1363,8 +1372,6 @@ pub enum MsgOut {
     Refresh,
     ClearScreen,
     Quit,
-    PrintResultAndQuit,
-    PrintAppStateAndQuit,
     Debug(String),
     Call(Command),
     CallSilently(Command),
@@ -1377,6 +1384,11 @@ pub enum MsgOut {
     StartFifo(String),
     StopFifo,
     ToggleFifo(String),
+    PrintPwdAndQuit,
+    PrintFocusPathAndQuit,
+    PrintSelectionAndQuit,
+    PrintResultAndQuit,
+    PrintAppStateAndQuit,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
@@ -1744,6 +1756,9 @@ impl App {
                 ExternalMsg::LogWarning(l) => self.log_warning(l),
                 ExternalMsg::LogError(l) => self.log_error(l),
                 ExternalMsg::Quit => self.quit(),
+                ExternalMsg::PrintPwdAndQuit => self.print_pwd_and_quit(),
+                ExternalMsg::PrintFocusPathAndQuit => self.print_focus_path_and_quit(),
+                ExternalMsg::PrintSelectionAndQuit => self.print_selection_and_quit(),
                 ExternalMsg::PrintResultAndQuit => self.print_result_and_quit(),
                 ExternalMsg::PrintAppStateAndQuit => self.print_app_state_and_quit(),
                 ExternalMsg::Debug(path) => self.debug(path),
@@ -2514,6 +2529,21 @@ impl App {
 
     fn quit(mut self) -> Result<Self> {
         self.msg_out.push_back(MsgOut::Quit);
+        Ok(self)
+    }
+
+    fn print_pwd_and_quit(mut self) -> Result<Self> {
+        self.msg_out.push_back(MsgOut::PrintPwdAndQuit);
+        Ok(self)
+    }
+
+    fn print_focus_path_and_quit(mut self) -> Result<Self> {
+        self.msg_out.push_back(MsgOut::PrintFocusPathAndQuit);
+        Ok(self)
+    }
+
+    fn print_selection_and_quit(mut self) -> Result<Self> {
+        self.msg_out.push_back(MsgOut::PrintSelectionAndQuit);
         Ok(self)
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -828,6 +828,9 @@ pub struct BuiltinModesConfig {
 
     #[serde(default)]
     pub switch_layout: Mode,
+
+    #[serde(default)]
+    pub quit: Mode,
 }
 
 impl BuiltinModesConfig {
@@ -857,6 +860,7 @@ impl BuiltinModesConfig {
             "relative path does not contain" => Some(&self.relative_path_does_not_contain),
             "switch layout" => Some(&self.switch_layout),
             "switch_layout" => Some(&self.switch_layout),
+            "quit" => Some(&self.quit),
             _ => None,
         }
     }
@@ -944,6 +948,11 @@ impl BuiltinModesConfig {
     /// Get a reference to the builtin modes config's recover.
     pub fn recover(&self) -> &Mode {
         &self.recover
+    }
+
+    /// Get a reference to the builtin modes config's quit.
+    pub fn quit(&self) -> &Mode {
+        &self.quit
     }
 }
 

--- a/src/init.lua
+++ b/src/init.lua
@@ -1345,9 +1345,10 @@ xplr.config.modes.builtin.action = {
         }
       },
       ["q"] = {
-        help = "quit",
+        help = "quit options",
         messages = {
-          "Quit",
+          "PopMode",
+          { SwitchModeBuiltin = "quit" },
         }
       }
     },
@@ -1364,6 +1365,59 @@ xplr.config.modes.builtin.action = {
     },
     on_special_character = nil,
     default = nil
+  }
+}
+
+------ Quit
+xplr.config.modes.builtin.quit = {
+  name = "quit",
+  help = nil,
+  extra_help = nil,
+  key_bindings = {
+    on_key = {
+      enter = {
+        help = "just quit",
+        messages = {
+          "Quit",
+        }
+      },
+      p = {
+        help = "quit printing pwd",
+        messages = {
+          "PrintPwdAndQuit",
+        }
+      },
+      f = {
+        help = "quit printing focus",
+        messages = {
+          "PrintFocusPathAndQuit",
+        }
+      },
+      s = {
+        help = "quit printing selection",
+        messages = {
+          "PrintSelectionAndQuit",
+        }
+      },
+      r = {
+        help = "quit printing result",
+        messages = {
+          "PrintResultAndQuit",
+        }
+      },
+      esc = {
+        help = "cancel",
+        messages = {
+          "PopMode",
+        }
+      },
+      ["ctrl-c"] = {
+        help = "terminate",
+        messages = {
+          "Terminate",
+        }
+      }
+    }
   }
 }
 

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -211,6 +211,23 @@ impl Runner {
                                 break 'outer;
                             }
 
+                            app::MsgOut::PrintPwdAndQuit => {
+                                result = Ok(Some(format!("{}\n", app.pwd())));
+                                break 'outer;
+                            }
+
+                            app::MsgOut::PrintFocusPathAndQuit => {
+                                result = Ok(app
+                                    .focused_node()
+                                    .map(|n| format!("{}\n", n.absolute_path())));
+                                break 'outer;
+                            }
+
+                            app::MsgOut::PrintSelectionAndQuit => {
+                                result = Ok(Some(app.selection_str()));
+                                break 'outer;
+                            }
+
                             app::MsgOut::PrintResultAndQuit => {
                                 result = Ok(Some(app.result_str()));
                                 break 'outer;


### PR DESCRIPTION
Adds the following messages:

- PrintPwdAndQuit
- PrintFocusPathAndQuit
- PrintSelectionAndQuit

And key bindings:

`:q<enter>` -> Quit.
`:qp` -> PrintPwdAndQuit.
`:qf` -> PrintFocusPathAndQuit.
`:qs` -> PrintSelectionAndQuit.
`:qr` -> PrintResultAndQuit.

Closed: https://github.com/sayanarijit/xplr/issues/257