### PR TITLE
Make the number of visible logs dynamic

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -857,7 +857,7 @@ fn draw_logs<B: Backend>(
         app.logs()
             .iter()
             .rev()
-            .take(1)
+            .take(layout_size.height as usize)
             .rev()
             .map(|l| {
                 let time = l.created_at().format("%r");


### PR DESCRIPTION
It helps to see all the logs when switching to a bigger InputAndLogs
layout.