### PR TITLE
Remove termion dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -571,12 +571,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "numtoa"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
-
-[[package]]
 name = "oorandom"
 version = "11.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -717,15 +711,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94341e4e44e24f6b591b59e47a8a027df12e008d73fd5672dbea9cc22f4507d9"
 dependencies = [
  "bitflags",
-]
-
-[[package]]
-name = "redox_termios"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8440d8acb4fd3d277125b4bd01a6f38aee8d814b3b5fc09b3f2b825d37d3fe8f"
-dependencies = [
- "redox_syscall",
 ]
 
 [[package]]
@@ -895,18 +880,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
-]
-
-[[package]]
-name = "termion"
-version = "1.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "077185e2eac69c3f8379a4298e1e07cd36beb962290d4a51199acf0fdc10607e"
-dependencies = [
- "libc",
- "numtoa",
- "redox_syscall",
- "redox_termios",
 ]
 
 [[package]]
@@ -1133,7 +1106,6 @@ dependencies = [
  "natord",
  "serde",
  "serde_yaml",
- "termion",
  "tui",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ name = "xplr"
 
 [dependencies]
 tui = { version = "0.15.0", default-features = false, features = ['crossterm', 'serde'] }
-termion = "1.5.6"
 crossterm = "0.19.0"
 dirs = "3.0.2"
 serde = { version = "1.0.126", features = ["derive"] }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -18,27 +18,27 @@ use std::io::Write;
 use std::path::PathBuf;
 use std::process::{Command, ExitStatus, Stdio};
 use std::sync::mpsc;
-use termion::get_tty;
 use tui::backend::CrosstermBackend;
 use tui::Terminal;
+
+fn get_tty() -> io::Result<fs::File> {
+    fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open("/dev/tty")
+}
 
 fn call_lua(
     app: &app::App,
     lua: &mlua::Lua,
     func: &str,
-    silent: bool,
+    _silent: bool,
 ) -> Result<Option<Vec<app::ExternalMsg>>> {
     let _focus_index = app
         .directory_buffer()
         .map(|d| d.focus())
         .unwrap_or_default()
         .to_string();
-
-    let (_, _, _) = if silent {
-        (Stdio::null(), Stdio::null(), Stdio::null())
-    } else {
-        (get_tty()?.into(), get_tty()?.into(), get_tty()?.into())
-    };
 
     let arg = app.to_lua_arg();
     let arg = lua.to_value(&arg)?;


### PR DESCRIPTION
Termion is only used to get TTY which is simple enough to implement.