### PR TITLE
Config and runtime  path access fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1075,7 +1075,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "xplr"
-version = "0.14.6"
+version = "0.14.7"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xplr"
-version = "0.14.6"  # Update lua.rs
+version = "0.14.7"  # Update lua.rs
 authors = ["Arijit Basu <sayanarijit@gmail.com>"]
 edition = "2018"
 description = "A hackable, minimal, fast TUI file explorer"

--- a/docs/en/src/upgrade-guide.md
+++ b/docs/en/src/upgrade-guide.md
@@ -46,7 +46,7 @@ compatibility.
 
 ### Instructions
 
-#### [v0.13.7][2] -> [v0.14.6][3]
+#### [v0.13.7][2] -> [v0.14.7][3]
 
 - macOS users need to place their config file (`init.lua`) in
   `$HOME/.config/xplr/` or `/etc/xplr/`.
@@ -222,7 +222,7 @@ Else do the following:
 
 [1]:#instructions
 [2]:https://github.com/sayanarijit/xplr/releases/tag/v0.13.7
-[3]:https://github.com/sayanarijit/xplr/releases/tag/v0.14.6
+[3]:https://github.com/sayanarijit/xplr/releases/tag/v0.14.7
 [4]:https://github.com/sayanarijit/xplr/pull/229#issue-662426960
 [5]:contribute.md
 [6]:https://github.com/sayanarijit/xplr/releases/tag/v0.12.1

--- a/src/app.rs
+++ b/src/app.rs
@@ -1545,14 +1545,26 @@ impl App {
         let mut config = lua::init(lua)?;
 
         let config_file = if let Some(path) = config_file {
-            path
+            Some(path)
         } else if let Some(dir) = dirs::home_dir() {
-            dir.join(".config").join("xplr").join("init.lua")
+            let path = dir.join(".config").join("xplr").join("init.lua");
+            if path.exists() {
+                Some(path)
+            } else {
+                None
+            }
         } else {
-            PathBuf::from("/").join("etc").join("xplr").join("init.lua")
+            let path = PathBuf::from("/").join("etc").join("xplr").join("init.lua");
+            if path.exists() {
+                Some(path)
+            } else {
+                None
+            }
         };
 
-        let config_files = std::iter::once(config_file).chain(extra_config_files.into_iter());
+        let config_files = std::iter::once(config_file)
+            .chain(extra_config_files.into_iter().map(Some))
+            .filter_map(|x| x);
 
         let mut load_errs = vec![];
         for config_file in config_files {

--- a/src/lua.rs
+++ b/src/lua.rs
@@ -133,30 +133,30 @@ mod test {
         assert!(check_version(VERSION, "foo path").is_ok());
 
         // Current release if OK
-        assert!(check_version("0.14.6", "foo path").is_ok());
+        assert!(check_version("0.14.7", "foo path").is_ok());
 
         // Prev major release is ERR
         // - Not yet
 
         // Prev minor release is ERR (Change when we get to v1)
-        assert!(check_version("0.13.6", "foo path").is_err());
+        assert!(check_version("0.13.7", "foo path").is_err());
 
         // Prev bugfix release is OK
-        assert!(check_version("0.14.5", "foo path").is_ok());
+        assert!(check_version("0.14.6", "foo path").is_ok());
 
         // Next major release is ERR
-        assert!(check_version("1.14.6", "foo path").is_err());
+        assert!(check_version("1.14.7", "foo path").is_err());
 
         // Next minor release is ERR
-        assert!(check_version("0.15.6", "foo path").is_err());
+        assert!(check_version("0.15.7", "foo path").is_err());
 
         // Next bugfix release is ERR (Change when we get to v1)
-        assert!(check_version("0.14.7", "foo path").is_err());
+        assert!(check_version("0.14.8", "foo path").is_err());
     }
 
     #[test]
     fn test_upgrade_guide_has_latest_version() {
-        let guide = std::fs::read_to_string("docs/en/src/upgrade-guide.md").unwrap();
+        let guide = include_str!("../docs/en/src/upgrade-guide.md");
         assert!(guide.contains(VERSION));
     }
 }


### PR DESCRIPTION
- Do not log error if config file is missing.
- Fallback to /tmp when runtime path is inaccessible.

Fixes: https://github.com/sayanarijit/xplr/issues/319