### PR TITLE
Some refactors

### DIFF
--- a/examples/run.rs
+++ b/examples/run.rs
@@ -1,5 +1,5 @@
 fn main() {
-    match xplr::runner(None).and_then(|a| a.run()) {
+    match xplr::runner::Runner::new(xplr::cli::Cli::default()).and_then(|a| a.run()) {
         Ok(Some(out)) => print!("{}", out),
         Ok(None) => {}
         Err(err) => {

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,3 +1,4 @@
+use crate::cli;
 use crate::config::Config;
 use crate::config::Mode;
 use crate::explorer;
@@ -2342,10 +2343,8 @@ impl App {
     fn select(mut self) -> Result<Self> {
         if let Some(n) = self.focused_node().map(|n| n.to_owned()) {
             self.selection.insert(n);
-            Ok(self)
-        } else {
-            Ok(self)
         }
+        Ok(self)
     }
 
     fn select_path(mut self, path: String) -> Result<Self> {
@@ -2357,10 +2356,8 @@ impl App {
         let filename = path.file_name().map(|p| p.to_string_lossy().to_string());
         if let (Some(p), Some(n)) = (parent, filename) {
             self.selection.insert(Node::new(p, n));
-            Ok(self)
-        } else {
-            Ok(self)
         }
+        Ok(self)
     }
 
     fn select_all(mut self) -> Result<Self> {
@@ -2903,6 +2900,6 @@ impl App {
     }
 }
 
-pub fn runner(path: Option<PathBuf>) -> Result<Runner> {
-    Runner::new(path)
+pub fn runner(cli: cli::Cli) -> Result<Runner> {
+    Runner::new(cli)
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,87 @@
+use anyhow::Result;
+use std::collections::VecDeque;
+use std::path::PathBuf;
+use std::{env, io};
+
+use crate::app;
+
+#[derive(Debug, Clone, Default)]
+pub struct Cli {
+    pub version: bool,
+    pub help: bool,
+    pub read_only: bool,
+    pub path: Option<PathBuf>,
+    pub config: Option<PathBuf>,
+    pub extra_config: Vec<PathBuf>,
+    pub on_load: Vec<app::ExternalMsg>,
+}
+
+impl Cli {
+    pub fn parse(args: env::Args) -> Result<Self> {
+        let mut args: VecDeque<String> = args.skip(1).collect();
+        let mut cli = Self::default();
+
+        while let Some(arg) = args.pop_front() {
+            match arg.as_str() {
+                // Flags
+                "-" => {
+                    let mut path = String::new();
+                    if io::stdin().read_line(&mut path).is_ok() {
+                        cli.path =
+                            Some(path.trim_end_matches("\r\n").trim_end_matches('\n').into());
+                    };
+                }
+
+                "-h" | "--help" => {
+                    cli.help = true;
+                }
+
+                "-V" | "--version" => {
+                    cli.version = true;
+                }
+
+                "--" => {
+                    if cli.path.is_none() {
+                        cli.path = args.pop_front().map(PathBuf::from);
+                    }
+                    return Ok(cli);
+                }
+
+                // Options
+                "-c" | "--config" => cli.config = args.pop_front().map(PathBuf::from),
+
+                "-C" | "--extra-config" => {
+                    while let Some(path) = args.pop_front() {
+                        if path.starts_with('-') {
+                            args.push_front(path);
+                            break;
+                        } else {
+                            cli.extra_config.push(PathBuf::from(path));
+                        }
+                    }
+                }
+
+                "--read-only" => cli.read_only = true,
+
+                "--on-load" => {
+                    while let Some(msg) = args.pop_front() {
+                        if msg.starts_with('-') {
+                            args.push_front(msg);
+                            break;
+                        } else {
+                            cli.on_load.push(serde_yaml::from_str(&msg)?);
+                        }
+                    }
+                }
+
+                // path
+                path => {
+                    if cli.path.is_none() {
+                        cli.path = Some(path.into());
+                    }
+                }
+            }
+        }
+        Ok(cli)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 #![allow(clippy::unnecessary_wraps)]
 
 pub mod app;
+pub mod cli;
 pub mod config;
 pub mod event_reader;
 pub mod explorer;
@@ -13,5 +14,3 @@ pub mod pipe_reader;
 pub mod pwd_watcher;
 pub mod runner;
 pub mod ui;
-
-pub use app::runner;


### PR DESCRIPTION
I Refactored parts of `runner::Runner` to take a Cli struct, instead of putting everything manually in `Runner`.
This is what you want to use most of the time. Otherwise your stuck with a lot of 
```rs
.and_then(|a| a.yyy(xxx))
```
in `xplr::runner::Runner`.
