### PR TITLE
Fix reading input

### DIFF
--- a/src/explorer.rs
+++ b/src/explorer.rs
@@ -61,7 +61,7 @@ pub(crate) fn explore_async(
                         MsgIn::Internal(InternalMsg::SetDirectory(buf)),
                         None,
                     ))
-                    .unwrap_or_default();
+                    .unwrap();
             })
             .unwrap_or_else(|e| {
                 tx_msg_in
@@ -69,7 +69,7 @@ pub(crate) fn explore_async(
                         MsgIn::External(ExternalMsg::LogError(e.to_string())),
                         None,
                     ))
-                    .unwrap_or_default();
+                    .unwrap();
             })
     });
 }

--- a/src/pwd_watcher.rs
+++ b/src/pwd_watcher.rs
@@ -23,7 +23,7 @@ pub fn keep_watching(
                 .map(|modified| {
                     if modified != last_modified {
                         let msg = MsgIn::External(ExternalMsg::ExplorePwdAsync);
-                        tx_msg_in.send(Task::new(msg, None)).unwrap_or_default();
+                        tx_msg_in.send(Task::new(msg, None)).unwrap();
                         last_modified = modified;
                     } else {
                         thread::sleep(Duration::from_secs(1));
@@ -31,7 +31,7 @@ pub fn keep_watching(
                 })
                 .unwrap_or_else(|e| {
                     let msg = MsgIn::External(ExternalMsg::LogError(e.to_string()));
-                    tx_msg_in.send(Task::new(msg, None)).unwrap_or_default();
+                    tx_msg_in.send(Task::new(msg, None)).unwrap();
                     thread::sleep(Duration::from_secs(1));
                 })
         }


### PR DESCRIPTION
Wait for confirmation after sending a message to a thread.

Also, use unwrap() to crash and burn than using unwrap_or_default() when
message passing fails.

It's highly unlikely to happen and also trivial to the core logic. But
let's see the error when it does happen.

Fixes https://github.com/sayanarijit/xplr/issues/301