### PR TITLE
Downgrade version for the docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1091,7 +1091,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "xplr"
-version = "0.15.1"
+version = "0.15.0"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xplr"
-version = "0.15.1"  # Update lua.rs
+version = "0.15.0"  # Update lua.rs
 authors = ["Arijit Basu <sayanarijit@gmail.com>"]
 edition = "2018"
 description = "A hackable, minimal, fast TUI file explorer"

--- a/docs/en/src/upgrade-guide.md
+++ b/docs/en/src/upgrade-guide.md
@@ -45,7 +45,7 @@ compatibility.
 
 ### Instructions
 
-#### [v0.14.7][3] -> [v0.15.1][43]
+#### [v0.14.7][3] -> [v0.15.0][43]
 
 - Deprecated `config` field from `CallLua` argument. Use the globally available
   `xplr.config` instead.
@@ -277,4 +277,4 @@ Else do the following:
 [40]: https://github.com/sayanarijit/xplr/releases/tag/v0.3.8
 [41]: https://github.com/sayanarijit/xplr/releases/tag/v0.3.0
 [42]: https://github.com/sayanarijit/xplr/releases/tag/v0.14.4
-[43]: https://github.com/sayanarijit/xplr/releases/tag/v0.15.1
+[43]: https://github.com/sayanarijit/xplr/releases/tag/v0.15.0

--- a/src/lua.rs
+++ b/src/lua.rs
@@ -133,25 +133,25 @@ mod test {
         assert!(check_version(VERSION, "foo path").is_ok());
 
         // Current release if OK
-        assert!(check_version("0.15.1", "foo path").is_ok());
+        assert!(check_version("0.15.0", "foo path").is_ok());
 
         // Prev major release is ERR
         // - Not yet
 
         // Prev minor release is ERR (Change when we get to v1)
-        assert!(check_version("0.14.1", "foo path").is_err());
+        assert!(check_version("0.14.0", "foo path").is_err());
 
         // Prev bugfix release is OK
-        assert!(check_version("0.15.0", "foo path").is_ok());
+        // assert!(check_version("0.15.-1", "foo path").is_ok());
 
         // Next major release is ERR
-        assert!(check_version("1.15.1", "foo path").is_err());
+        assert!(check_version("1.15.0", "foo path").is_err());
 
         // Next minor release is ERR
-        assert!(check_version("0.16.1", "foo path").is_err());
+        assert!(check_version("0.16.0", "foo path").is_err());
 
         // Next bugfix release is ERR (Change when we get to v1)
-        assert!(check_version("0.15.2", "foo path").is_err());
+        assert!(check_version("0.15.1", "foo path").is_err());
     }
 
     #[test]


### PR DESCRIPTION
Upgrade version when just before making a new release, else the doc will
link to invalid release.