### PR TITLE
Add a trace level to test CI task

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,8 @@ jobs:
     name: Test Suite
     runs-on: ubuntu-latest
     needs: prepare
+    env:
+      RUST_BACKTRACE: full
     steps:
       - uses: actions/checkout@master
       - uses: actions-rs/toolchain@v1


### PR DESCRIPTION
To enable to get stack trace on CI, add a `RUST_BACKTRACE` env
variable. It is useful to debug.

Some rust projects applied this parameter. e.g. deno
https://github.com/denoland/deno/blob/main/.github/workflows/ci.yml#L54