### PR TITLE
Change mods name for tests

### DIFF
--- a/src/lua.rs
+++ b/src/lua.rs
@@ -124,7 +124,7 @@ pub fn call<'lua, R: Deserialize<'lua>>(
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
 
     use super::*;
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1179,7 +1179,7 @@ pub fn draw<B: Backend>(f: &mut Frame<B>, app: &app::App, lua: &Lua) {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
     use tui::style::Color;
 


### PR DESCRIPTION
There are two mod names for test, `test` and `tests`. This commit unifies
the name to `tests`. It is commonly used.