### PR TITLE
Introduce `general.hide_remaps_in_help_menu` config entry.

### DIFF
--- a/docs/en/src/general-config.md
+++ b/docs/en/src/general-config.md
@@ -29,11 +29,11 @@ Type: boolean
 Set it to `true` if you want to enable a safety feature that will save you from
 yourself when you type recklessly.
 
-## help_hide_remaps
+## hide_remaps_in_help_menu
 
 Type: boolean
 
-Set it to `true` if you want to hide all remaps in the help buffer, except one.
+Set it to `true` if you want to hide all remaps in the help buffer.
 
 ## initial_layout
 

--- a/docs/en/src/general-config.md
+++ b/docs/en/src/general-config.md
@@ -29,6 +29,12 @@ Type: boolean
 Set it to `true` if you want to enable a safety feature that will save you from
 yourself when you type recklessly.
 
+## help_hide_remaps
+
+Type: boolean
+
+Set it to `true` if you want to hide all remaps in the help buffer, except one.
+
 ## initial_layout
 
 Type: string

--- a/docs/en/src/general-config.md
+++ b/docs/en/src/general-config.md
@@ -33,7 +33,7 @@ yourself when you type recklessly.
 
 Type: boolean
 
-Set it to `true` if you want to hide all remaps in the help buffer.
+Set it to `true` if you want to hide all remaps in the help menu.
 
 ## initial_layout
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -228,6 +228,9 @@ pub struct GeneralConfig {
     pub enable_recover_mode: bool,
 
     #[serde(default)]
+    pub help_hide_remaps: bool,
+
+    #[serde(default)]
     pub prompt: UiElement,
 
     #[serde(default)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -228,7 +228,7 @@ pub struct GeneralConfig {
     pub enable_recover_mode: bool,
 
     #[serde(default)]
-    pub help_hide_remaps: bool,
+    pub hide_remaps_in_help_menu: bool,
 
     #[serde(default)]
     pub prompt: UiElement,

--- a/src/init.lua
+++ b/src/init.lua
@@ -19,6 +19,9 @@ xplr.config.general.enable_recover_mode = false
 ------ Start FIFO
 xplr.config.general.start_fifo = nil
 
+------ Hide remaps in help menu
+xplr.config.general.help_hide_remaps = false
+
 ------ Prompt
 xplr.config.general.prompt.format = "❯ "
 xplr.config.general.prompt.style.add_modifiers = nil

--- a/src/init.lua
+++ b/src/init.lua
@@ -20,7 +20,7 @@ xplr.config.general.enable_recover_mode = false
 xplr.config.general.start_fifo = nil
 
 ------ Hide remaps in help menu
-xplr.config.general.help_hide_remaps = false
+xplr.config.general.hide_remaps_in_help_menu = false
 
 ------ Prompt
 xplr.config.general.prompt.format = "❯ "

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -738,7 +738,7 @@ fn draw_help_menu<B: Backend>(
         .map(|l| match l {
             HelpMenuLine::Paragraph(p) => Row::new([Cell::from(p)].to_vec()),
             HelpMenuLine::KeyMap(k, remaps, h) => Row::new({
-                if app.config.general.help_hide_remaps {
+                if app.config.general.hide_remaps_in_help_menu {
                     [Cell::from(k), Cell::from(h)].to_vec()
                 } else {
                     [Cell::from(k), Cell::from(remaps.join("|")), Cell::from(h)]
@@ -753,7 +753,7 @@ fn draw_help_menu<B: Backend>(
             config,
             format!(" Help [{}{}] ", &app.mode.name, read_only_indicator(app)),
         ))
-        .widths(if app.config.general.help_hide_remaps {
+        .widths(if app.config.general.hide_remaps_in_help_menu {
             &[TuiConstraint::Percentage(20), TuiConstraint::Percentage(80)]
         } else {
             &[

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -737,10 +737,14 @@ fn draw_help_menu<B: Backend>(
         .into_iter()
         .map(|l| match l {
             HelpMenuLine::Paragraph(p) => Row::new([Cell::from(p)].to_vec()),
-            HelpMenuLine::KeyMap(k, remaps, h) => Row::new(
-                [Cell::from(k), Cell::from(remaps.join("|")), Cell::from(h)]
-                    .to_vec(),
-            ),
+            HelpMenuLine::KeyMap(k, remaps, h) => Row::new({
+                if app.config.general.help_hide_remaps {
+                    [Cell::from(k), Cell::from(h)].to_vec()
+                } else {
+                    [Cell::from(k), Cell::from(remaps.join("|")), Cell::from(h)]
+                        .to_vec()
+                }
+            }),
         })
         .collect::<Vec<Row>>();
 
@@ -749,11 +753,15 @@ fn draw_help_menu<B: Backend>(
             config,
             format!(" Help [{}{}] ", &app.mode.name, read_only_indicator(app)),
         ))
-        .widths(&[
-            TuiConstraint::Percentage(20),
-            TuiConstraint::Percentage(20),
-            TuiConstraint::Percentage(60),
-        ]);
+        .widths(if app.config.general.help_hide_remaps {
+            &[TuiConstraint::Percentage(20), TuiConstraint::Percentage(80)]
+        } else {
+            &[
+                TuiConstraint::Percentage(20),
+                TuiConstraint::Percentage(20),
+                TuiConstraint::Percentage(60),
+            ]
+        });
     f.render_widget(help_menu, layout_size);
 }
 


### PR DESCRIPTION
Motivation: 
I wanted to disable remaps in my config, but I found there is no way of doing that in the latest release, except for removing code.

I've allowed edits, so that if you don't like the naming of the config entry, you can change it.

Now you can do `xplr.config.general.help_hide_remaps = true` to hide all remaps, except one.