### PR TITLE
CLI for a better "cd on quit"

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -2647,6 +2647,10 @@ impl App {
             .unwrap_or_default()
     }
 
+    pub fn pwd_str(&self) -> String {
+        format!("{}\n", &self.pwd)
+    }
+
     pub fn selection_str(&self) -> String {
         self.selection
             .iter()

--- a/src/bin/xplr.rs
+++ b/src/bin/xplr.rs
@@ -27,7 +27,10 @@ fn main() {
                                       "$HOME/.config/xplr/init.lua")
     -C, --extra-config <PATH>...    Specifies extra config files to load
         --on-load <MESSAGE>...      Sends messages when xplr loads
-        --force-focus               Focuses on the given <PATH>, even if directory"###;
+        --force-focus               Focuses on the given <PATH>, even if it is
+                                      a directory
+        --print-pwd-as-result       Prints the last working directory when
+                                      quitting with `PrintResultAndQuit`"###;
 
         let args = r###"
     <PATH>            Path to focus on, or enter if directory, (default is `.`)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -13,6 +13,7 @@ pub struct Cli {
     pub help: bool,
     pub read_only: bool,
     pub force_focus: bool,
+    pub print_pwd_as_result: bool,
     pub config: Option<PathBuf>,
     pub extra_config: Vec<PathBuf>,
     pub on_load: Vec<app::ExternalMsg>,
@@ -96,6 +97,10 @@ impl Cli {
 
                     "--force-focus" => {
                         cli.force_focus = true;
+                    }
+
+                    "--print-pwd-as-result" => {
+                        cli.print_pwd_as_result = true;
                     }
 
                     // path


### PR DESCRIPTION
Use `--print-pwd-as-result` to print the last working directory instead
of the focused or selected nodes, when you quit using the `PrintResultAndQuit`
message (i.e. by pressing `enter`).

This helps with implementing the "cd on quit" functionality using a plain shell
alias.

Example:

```
alias xcd='cd "$(xplr --print-pwd-as-result)"'
```

With this alias set, you can navigate directories using xplr by entering
`xcd` command, and when you quit by pressing enter, you will enter the
directory.

You can of course, quit with plain `Quit` (i.e. by pressing `esc`) to
gracefully cancel "cd on quit".