### PR TITLE
Support custom `border_type` and `border_style`

### DIFF
--- a/docs/en/src/general-config.md
+++ b/docs/en/src/general-config.md
@@ -360,6 +360,24 @@ sort_and_filter_ui.sorter_identifiers.ByCanonicalAbsolutePath = {
 }
 ```
 
+## panel_ui.default.style
+
+Type: [Style][1]
+
+Default style for panels.
+
+## panel_ui.default.title.format
+
+Type: nullable string
+
+The content for panel title.
+
+## panel_ui.default.title.style
+
+Type: [Style][1]
+
+Style for panel title.
+
 ## panel_ui.default.borders
 
 Type: nullable list of strings
@@ -379,32 +397,33 @@ xplr.config.general.panel_ui.default.borders = {
 }
 ```
 
-## panel_ui.default.style
+## panel_ui.default.border_type
+
+Type: string
+
+Defines the type of the borders.
+
+The possible values are any combination of: "Plain", "Rounder", "Double" and
+"Thick".
+
+Example:
+
+```lua
+xplr.config.general.panel_ui.default.border_type = "Thick"
+```
+
+## panel_ui.default.border_style
 
 Type: [Style][1]
 
-Default style for panels.
+Defines the style of the borders.
 
-## panel_ui.default.title.format
+Example:
 
-Type: nullable string
-
-The content for panel title.
-
-## panel_ui.default.title.style
-
-Type: [Style][1]
-
-Style for panel title.
-
-## panel_ui.help_menu.borders
-
-Type: nullable list of strings
-
-Defines where to show borders for the `Help` panel.
-
-The possible values are any combination of: "Top", "Bottom", "Left" and
-"Right".
+```lua
+xplr.config.general.panel_ui.default.border_style.fg = "Black"
+xplr.config.general.panel_ui.default.border_style.bg = "Gray"
+```
 
 ## panel_ui.help_menu.style
 
@@ -424,14 +443,29 @@ Type: [Style][1]
 
 Style for `Help` panel title.
 
-## panel_ui.input_and_logs.borders
+## panel_ui.help_menu.borders
 
 Type: nullable list of strings
 
-Defines where to show borders for the `Input` & `Logs` panel.
+Defines where to show borders for the `Help` panel.
 
 The possible values are any combination of: "Top", "Bottom", "Left" and
 "Right".
+
+## panel_ui.help_menu.border_type
+
+Type: string
+
+Defines the type of the borders.
+
+The possible values are any combination of: "Plain", "Rounder", "Double" and
+"Thick".
+
+## panel_ui.help_menu.border_style
+
+Type: [Style][1]
+
+Defines the style of the borders.
 
 ## panel_ui.input_and_logs.style
 
@@ -451,14 +485,29 @@ Type: [Style][1]
 
 Style for `Input` & `Logs` panel title.
 
-## panel_ui.selection.borders
+## panel_ui.input_and_logs.borders
 
 Type: nullable list of strings
 
-Defines where to show borders for the `Selection` panel.
+Defines where to show borders for the `Input` & `Logs` panel.
 
 The possible values are any combination of: "Top", "Bottom", "Left" and
 "Right".
+
+## panel_ui.input_and_logs.border_type
+
+Type: string
+
+Defines the type of the borders.
+
+The possible values are any combination of: "Plain", "Rounder", "Double" and
+"Thick".
+
+## panel_ui.input_and_logs.border_style
+
+Type: [Style][1]
+
+Defines the style of the borders.
 
 ## panel_ui.selection.style
 
@@ -478,14 +527,29 @@ Type: [Style][1]
 
 Style for `Selection` panel title.
 
-## panel_ui.sort_and_filter.borders
+## panel_ui.selection.borders
 
 Type: nullable list of strings
 
-Defines where to show borders for the `Sort & filter` panel.
+Defines where to show borders for the `Selection` panel.
 
 The possible values are any combination of: "Top", "Bottom", "Left" and
 "Right".
+
+## panel_ui.selection.border_type
+
+Type: string
+
+Defines the type of the borders.
+
+The possible values are any combination of: "Plain", "Rounder", "Double" and
+"Thick".
+
+## panel_ui.selection.border_style
+
+Type: [Style][1]
+
+Defines the style of the borders.
 
 ## panel_ui.sort_and_filter.style
 
@@ -504,6 +568,30 @@ The content for `Sort & filter` panel title.
 Type: [Style][1]
 
 Style for `Sort & filter` panel title.
+
+## panel_ui.sort_and_filter.borders
+
+Type: nullable list of strings
+
+Defines where to show borders for the `Sort & filter` panel.
+
+The possible values are any combination of: "Top", "Bottom", "Left" and
+"Right".
+
+## panel_ui.sort_and_filter.border_type
+
+Type: string
+
+Defines the type of the borders.
+
+The possible values are any combination of: "Plain", "Rounder", "Double" and
+"Thick".
+
+## panel_ui.sort_and_filter.border_style
+
+Type: [Style][1]
+
+Defines the style of the borders.
 
 [1]: style.md
 [2]: layouts.md

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,6 +4,7 @@ use crate::app::NodeFilter;
 use crate::app::NodeSorter;
 use crate::app::NodeSorterApplicable;
 use crate::ui::Border;
+use crate::ui::BorderType;
 use crate::ui::Constraint;
 use crate::ui::Layout;
 use crate::ui::Style;
@@ -648,17 +649,25 @@ pub struct PanelUiConfig {
     pub title: UiElement,
 
     #[serde(default)]
+    pub style: Style,
+
+    #[serde(default)]
     pub borders: Option<IndexSet<Border>>,
 
     #[serde(default)]
-    pub style: Style,
+    pub border_type: Option<BorderType>,
+
+    #[serde(default)]
+    pub border_style: Style,
 }
 
 impl PanelUiConfig {
     pub fn extend(mut self, other: &Self) -> Self {
         self.title = self.title.extend(&other.title);
-        self.borders = other.borders.to_owned().or(self.borders);
         self.style = self.style.extend(&other.style);
+        self.borders = other.borders.to_owned().or(self.borders);
+        self.border_type = other.border_type.to_owned().or(self.border_type);
+        self.border_style = self.border_style.extend(&other.border_style);
         self
     }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -22,7 +22,8 @@ use tui::layout::{
 use tui::style::{Color, Modifier as TuiModifier, Style as TuiStyle};
 use tui::text::{Span, Spans, Text};
 use tui::widgets::{
-    Block, Borders as TuiBorders, Cell, List, ListItem, Paragraph, Row, Table,
+    Block, BorderType as TuiBorderType, Borders as TuiBorders, Cell, List,
+    ListItem, Paragraph, Row, Table,
 };
 use tui::Frame;
 
@@ -179,6 +180,34 @@ impl Border {
             Self::Right => TuiBorders::RIGHT.bits(),
             Self::Bottom => TuiBorders::BOTTOM.bits(),
             Self::Left => TuiBorders::LEFT.bits(),
+        }
+    }
+}
+
+#[derive(
+    Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Serialize, Deserialize,
+)]
+#[serde(deny_unknown_fields)]
+pub enum BorderType {
+    Plain,
+    Rounded,
+    Double,
+    Thick,
+}
+
+impl Default for BorderType {
+    fn default() -> Self {
+        Self::Plain
+    }
+}
+
+impl Into<TuiBorderType> for BorderType {
+    fn into(self) -> TuiBorderType {
+        match self {
+            BorderType::Plain => TuiBorderType::Plain,
+            BorderType::Rounded => TuiBorderType::Rounded,
+            BorderType::Double => TuiBorderType::Double,
+            BorderType::Thick => TuiBorderType::Thick,
         }
     }
 }
@@ -458,6 +487,8 @@ fn block<'a>(config: PanelUiConfig, default_title: String) -> Block<'a> {
             config.title.style.into(),
         ))
         .style(config.style.into())
+        .border_type(config.border_type.unwrap_or_default().into())
+        .border_style(config.border_style.into())
 }
 
 fn draw_table<B: Backend>(
@@ -898,8 +929,7 @@ fn draw_sort_n_filter<B: Backend>(
             ui.separator.format.to_owned().unwrap_or_default(),
             ui.separator.style.to_owned().into(),
         )))
-        .map(|((a, b), c)| vec![a, b, c])
-        .flatten()
+        .flat_map(|((a, b), c)| vec![a, b, c])
         .collect::<Vec<Span>>();
     spans.pop();
 


### PR DESCRIPTION
This adds support for defining custom border types and border styles.

Example:

```
xplr.config.general.panel_ui.default.border_type = "Thick"
xplr.config.general.panel_ui.default.border_style.fg = "Black"
xplr.config.general.panel_ui.default.border_style.bg = "Gray"
```

Closes: https://github.com/sayanarijit/xplr/issues/448