### PR TITLE
Add initial support for hooks

### DIFF
--- a/docs/en/src/configuration.md
+++ b/docs/en/src/configuration.md
@@ -76,3 +76,25 @@ in `xplr.fn.custom`.
 
 You can also use nested tables such as
 `xplr.fn.custom.my_plugin.my_function` to define custom functions.
+
+## Hooks
+
+This section of the configuration cannot be overwritten by another config
+file, as it is an optional lua return statement specific to each config
+file. It can be used to define things that are append only, such as various
+hooks and callbacks.
+
+Example:
+
+```lua
+return {
+  -- Messages to send when the config file loads.
+  -- This is similar to the `--on-load` command-line option.
+  --
+  -- Type: list of [Message](https://xplr.dev/en/message#message)s
+  on_load = {
+    { LogInfo = "Hello xplr user," },
+    { LogSuccess = "Configuration successfully loaded!" },
+  }
+}
+```

--- a/docs/script/generate.py
+++ b/docs/script/generate.py
@@ -4,7 +4,6 @@ import os
 from dataclasses import dataclass
 from typing import List
 
-
 # Messages --------------------------------------------------------------------
 
 MESSAGES_DOC_TEMPLATE = """
@@ -157,6 +156,7 @@ def gen_configuration():
             line.startswith("-- # Configuration ")
             or line.startswith("-- ## Config ")
             or line.startswith("-- ## Function ")
+            or line.startswith("-- ## On Load ")
         ):
             reading = configuration
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -189,7 +189,7 @@ fn fmt_msg_in(args: Vec<String>) -> Result<String> {
             }
             ('q', Some('%')) => {
                 let arg = args.next().context(format!(
-                    "argument missing for the placeholder at col {}",
+                    "argument missing for the placeholder at column {}",
                     col
                 ))?;
                 msg.push_str(&json::to_string(&arg)?);
@@ -197,7 +197,7 @@ fn fmt_msg_in(args: Vec<String>) -> Result<String> {
             }
             ('s', Some('%')) => {
                 let arg = args.next().context(format!(
-                    "argument missing for the placeholder at col {}",
+                    "argument missing for the placeholder at column {}",
                     col
                 ))?;
                 msg.push_str(&arg);
@@ -205,7 +205,7 @@ fn fmt_msg_in(args: Vec<String>) -> Result<String> {
             }
             (ch, Some('%')) => {
                 bail!(format!(
-                    "invalid placeholder (%{}) at col {}, use one of %s %q %%",
+                    "invalid placeholder '%{}' at column {}, use one of '%s' or '%q', or escape it using '%%'",
                     ch, col
                 ));
             }

--- a/src/config.rs
+++ b/src/config.rs
@@ -612,3 +612,10 @@ pub struct Config {
     #[serde(default)]
     pub modes: ModesConfig,
 }
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Hooks {
+    #[serde(default)]
+    pub on_load: Vec<ExternalMsg>,
+}

--- a/src/init.lua
+++ b/src/init.lua
@@ -2563,3 +2563,29 @@ end
 -- You can also use nested tables such as
 -- `xplr.fn.custom.my_plugin.my_function` to define custom functions.
 xplr.fn.custom = {}
+
+-- ## Hooks -------------------------------------------------------------------
+--
+-- This section of the configuration cannot be overwritten by another config
+-- file, as it is an optional lua return statement specific to each config
+-- file. It can be used to define things that are append only, such as various
+-- hooks and callbacks.
+--
+-- Example:
+--
+-- ```lua
+-- return {
+--   -- Add messages to send when the xplr loads.
+--   -- This is similar to the `--on-load` command-line option.
+--   --
+--   -- Type: list of [Message](https://xplr.dev/en/message#message)s
+--   on_load = {
+--     { LogInfo = "Hello xplr user," },
+--     { LogSuccess = "Configuration successfully loaded!" },
+--   }
+-- }
+-- ```
+
+return {
+  on_load = {},
+}

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -245,7 +245,7 @@ impl Runner {
     pub fn run(self) -> Result<Option<String>> {
         // Why unsafe? See https://github.com/sayanarijit/xplr/issues/309
         let lua = unsafe { mlua::Lua::unsafe_new() };
-        let mut app = app::App::create(
+        let (mut app, hooks) = app::App::create(
             self.bin,
             self.pwd,
             &lua,
@@ -329,7 +329,12 @@ impl Runner {
         event_reader.start();
 
         // Enqueue on_load messages
-        for msg in self.on_load {
+        for msg in hooks
+            .unwrap_or_default()
+            .on_load
+            .into_iter()
+            .chain(self.on_load)
+        {
             tx_msg_in.send(app::Task::new(app::MsgIn::External(msg), None))?;
         }
 


### PR DESCRIPTION
A new optional section of the configuration defined using the lua return
statement, which can be used to define append only things, such as hooks
and callbacks, specific to each config file.

Example

```lua
version = "0.0.0"

return {
  -- Adds messages to pass when xplr loads (similar to `--on-load`)
  on_load = {
    { LogInfo = "Hello xplr user," },
    { LogSuccess = "Configuration successfully loaded!" },
  }
}
```