### PR TITLE
Add support for --vroot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1251,6 +1251,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c831fbbee9e129a8cf93e7747a82da9d95ba8e16621cae60ec2cdc849bacb7b"
+dependencies = [
+ "either",
+ "libc",
+ "once_cell",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1365,4 +1376,5 @@ dependencies = [
  "serde_yaml",
  "tui",
  "tui-input",
+ "which",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -733,6 +733,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "path-absolutize"
+version = "3.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f1d4993b16f7325d90c18c3c6a3327db7808752db8d208cea0acee0abd52c52"
+dependencies = [
+ "path-dedot",
+]
+
+[[package]]
+name = "path-dedot"
+version = "3.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a81540d94551664b72b72829b12bd167c73c9d25fbac0e04fafa8023f7e4901"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1340,6 +1358,7 @@ dependencies = [
  "mime_guess",
  "mlua",
  "natord",
+ "path-absolutize",
  "regex",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ gethostname = "0.3.0"
 fuzzy-matcher = "0.3.7"
 serde_json = "1.0.87"
 path-absolutize = "3.0.14"
+which = "4.3.0"
 
 [dependencies.lazy_static]
 version = "1.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ regex = "1.6.0"
 gethostname = "0.3.0"
 fuzzy-matcher = "0.3.7"
 serde_json = "1.0.87"
+path-absolutize = "3.0.14"
 
 [dependencies.lazy_static]
 version = "1.4.0"

--- a/docs/en/src/environment-variables-and-pipes.md
+++ b/docs/en/src/environment-variables-and-pipes.md
@@ -52,6 +52,7 @@ The other variables are single-line variables containing simple information:
 - [XPLR_MODE][34]
 - [XPLR_PID][35]
 - [XPLR_SESSION_PATH][36]
+- [XPLR_VROOT][39]
 
 ### Environment variables
 
@@ -89,6 +90,10 @@ Contains the process ID of the current xplr process.
 
 Contains the current session path, like /tmp/runtime-"$USER"/xplr/session/"$XPLR_PID"/,
 you can find temporary files here, such as pipes.
+
+#### XPLR_VROOT
+
+Contains the path of current virtual root, is set.
 
 ### Pipes
 
@@ -214,3 +219,4 @@ xplr.config.modes.builtin.default.key_bindings.on_key.X = {
 [36]: #xplr_session_path
 [37]: messages.md#reading-input
 [38]: #xplr
+[39]: #xplr_vroot

--- a/docs/en/src/layout.md
+++ b/docs/en/src/layout.md
@@ -384,6 +384,7 @@ Hence, only the following fields are avilable.
 
 - [version][40]
 - [pwd][41]
+- [vroot][52]
 - [focused_node][42]
 - [selection][43]
 - [mode][44]
@@ -448,3 +449,4 @@ Hence, only the following fields are avilable.
 [49]: lua-function-calls.md#explorer_config
 [50]: lua-function-calls.md#directory_buffer
 [51]: layouts.md
+[52]: #vroot

--- a/docs/en/src/lua-function-calls.md
+++ b/docs/en/src/lua-function-calls.md
@@ -17,6 +17,7 @@ It contains the following information:
 
 - [version][29]
 - [pwd][31]
+- [vroot][75]
 - [focused_node][32]
 - [directory_buffer][33]
 - [selection][34]
@@ -39,7 +40,13 @@ xplr version. Can be used to test compatibility.
 
 Type: string
 
-The present working directory/
+The present working directory.
+
+### vroot
+
+Type: nullable string
+
+The current virtual root.
 
 ### focused_node
 
@@ -384,3 +391,4 @@ xplr.config.modes.builtin.default.key_bindings.on_key.space = {
 [72]: #last_modified
 [73]: #uid
 [74]: #gid
+[75]: #vroot

--- a/docs/en/src/messages.md
+++ b/docs/en/src/messages.md
@@ -310,6 +310,27 @@ Example:
 Lua: `"FollowSymlink"`
 YAML: `FollowSymlink`
 
+#### SetVroot
+
+Sets the virtual root for isolating xplr navigation, similar to `--vroot`.
+If the $PWD is outside the vroot, xplr will automatically enter vroot.
+
+Type: { SetVroot = "string" }
+
+Example:
+
+Lua: `{ SetVroot = "/tmp" }`
+YAML: `SetVroot: /tmp`
+
+#### ResetVroot
+
+Resets the virtual root bach to the value passed by `--vroot` or `/`.
+
+Example:
+
+- Lua: `"ResetVroot"`
+- YAML: `ResetVroot`
+
 ### Reading Input
 
 #### SetInputPrompt

--- a/docs/en/src/upgrade-guide.md
+++ b/docs/en/src/upgrade-guide.md
@@ -65,6 +65,9 @@ compatibility.
   - on_load
   - on_focus_change
   - on_directory_change
+- Use `--vroot` to isolate navigation of an xplr session inside a specific
+  directory. Interaction still requires passing full path, and shell,
+  lua functions etc still can access paths outside vroot.
 
 #### [v0.18.0][46] -> [v0.19.4][47]
 

--- a/src/bin/xplr.rs
+++ b/src/bin/xplr.rs
@@ -1,7 +1,6 @@
 #![allow(clippy::too_many_arguments)]
 
 use std::env;
-
 use xplr::cli::{self, Cli};
 use xplr::runner;
 
@@ -36,7 +35,9 @@ fn main() {
     -c, --config <PATH>             Specifies a custom config file (default is
                                       "$HOME/.config/xplr/init.lua")
     -C, --extra-config <PATH>...    Specifies extra config files to load
-        --on-load <MESSAGE>...      Sends messages when xplr loads"###;
+        --on-load <MESSAGE>...      Sends messages when xplr loads
+        --vroot <PATH>              Treats the specified path as the virtual root for
+                                      navigation, but uses full path for interaction"###;
 
         let args = r###"
     <PATH>            Path to focus on, or enter if directory, (default is `.`)

--- a/src/bin/xplr.rs
+++ b/src/bin/xplr.rs
@@ -36,8 +36,7 @@ fn main() {
                                       "$HOME/.config/xplr/init.lua")
     -C, --extra-config <PATH>...    Specifies extra config files to load
         --on-load <MESSAGE>...      Sends messages when xplr loads
-        --vroot <PATH>              Treats the specified path as the virtual root for
-                                      navigation, but uses full path for interaction"###;
+        --vroot <PATH>              Treats the specified path as the virtual root"###;
 
         let args = r###"
     <PATH>            Path to focus on, or enter if directory, (default is `.`)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -47,7 +47,15 @@ impl Cli {
     pub fn parse(args: env::Args) -> Result<Self> {
         let mut cli = Self::default();
         let mut args = args.peekable();
-        cli.bin = args.next().context("failed to parse xplr binary path")?;
+        cli.bin = args
+            .next()
+            .map(which::which)
+            .context("failed to parse xplr binary path")?
+            .context("failed to find xplr binary path")?
+            .absolutize()?
+            .to_path_buf()
+            .to_string_lossy()
+            .to_string();
 
         let mut flag_ends = false;
 

--- a/src/explorer.rs
+++ b/src/explorer.rs
@@ -102,7 +102,7 @@ pub(crate) fn explore_async(
 
 pub(crate) fn explore_recursive_async(
     config: ExplorerConfig,
-    root: PathBuf,
+    vroot: Option<PathBuf>,
     parent: PathBuf,
     focused_path: Option<PathBuf>,
     fallback_focus: usize,
@@ -116,10 +116,14 @@ pub(crate) fn explore_recursive_async(
         tx_msg_in.clone(),
     );
     if let Some(grand_parent) = parent.parent() {
-        if grand_parent.starts_with(&root) {
+        if vroot
+            .as_ref()
+            .map(|v| grand_parent.starts_with(v))
+            .unwrap_or(true)
+        {
             explore_recursive_async(
                 config,
-                root,
+                vroot,
                 grand_parent.into(),
                 parent.file_name().map(|p| p.into()),
                 0,

--- a/src/explorer.rs
+++ b/src/explorer.rs
@@ -102,6 +102,7 @@ pub(crate) fn explore_async(
 
 pub(crate) fn explore_recursive_async(
     config: ExplorerConfig,
+    root: PathBuf,
     parent: PathBuf,
     focused_path: Option<PathBuf>,
     fallback_focus: usize,
@@ -115,13 +116,16 @@ pub(crate) fn explore_recursive_async(
         tx_msg_in.clone(),
     );
     if let Some(grand_parent) = parent.parent() {
-        explore_recursive_async(
-            config,
-            grand_parent.into(),
-            parent.file_name().map(|p| p.into()),
-            0,
-            tx_msg_in,
-        );
+        if grand_parent.starts_with(&root) {
+            explore_recursive_async(
+                config,
+                root,
+                grand_parent.into(),
+                parent.file_name().map(|p| p.into()),
+                0,
+                tx_msg_in,
+            );
+        }
     }
 }
 

--- a/src/init.lua
+++ b/src/init.lua
@@ -1827,9 +1827,9 @@ xplr.config.modes.builtin.action = {
       ["!"] = {
         help = "shell",
         messages = {
+          "PopMode",
           { Call0 = { command = "bash", args = { "-i" } } },
           "ExplorePwdAsync",
-          "PopModeKeepingInputBuffer",
         },
       },
       ["c"] = {

--- a/src/msg/in_/external.rs
+++ b/src/msg/in_/external.rs
@@ -258,7 +258,6 @@ pub enum ExternalMsg {
     /// - YAML: `NextVisitedPath`
     NextVisitedPath,
 
-    ///
     /// Follow the symlink under focus to its actual location.
     ///
     /// Example:
@@ -266,6 +265,25 @@ pub enum ExternalMsg {
     /// Lua: `"FollowSymlink"`
     /// YAML: `FollowSymlink`
     FollowSymlink,
+
+    /// Sets the virtual root for isolating xplr navigation, similar to `--vroot`.
+    /// If the $PWD is outside the vroot, xplr will automatically enter vroot.
+    ///
+    /// Type: { SetVroot = "string" }
+    ///
+    /// Example:
+    ///
+    /// Lua: `{ SetVroot = "/tmp" }`
+    /// YAML: `SetVroot: /tmp`
+    SetVroot(String),
+
+    /// Resets the virtual root bach to the value passed by `--vroot` or `/`.
+    ///
+    /// Example:
+    ///
+    /// - Lua: `"ResetVroot"`
+    /// - YAML: `ResetVroot`
+    ResetVroot,
 
     /// ### Reading Input -----------------------------------------------------
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -669,13 +669,16 @@ fn draw_table<B: Backend>(
         .map(|c| c.to_tui(screen_size, layout_size))
         .collect();
 
-    let pwd = app
-        .pwd
-        .strip_prefix(&app.vroot)
-        .unwrap_or(&app.pwd)
-        .trim_matches('/')
-        .replace('\\', "\\\\")
-        .replace('\n', "\\n");
+    let pwd = if let Some(vroot) = app.vroot.as_ref() {
+        app.pwd.strip_prefix(vroot).unwrap_or(&app.pwd)
+    } else {
+        &app.pwd
+    }
+    .trim_matches('/')
+    .replace('\\', "\\\\")
+    .replace('\n', "\\n");
+
+    let vroot_indicator = if app.vroot.is_some() { "[v] " } else { "" };
 
     let table = Table::new(rows)
         .widths(&table_constraints)
@@ -685,7 +688,8 @@ fn draw_table<B: Backend>(
         .block(block(
             config,
             format!(
-                " /{} ({}) ",
+                " {}/{} ({}) ",
+                vroot_indicator,
                 pwd,
                 app.directory_buffer
                     .as_ref()

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -669,6 +669,14 @@ fn draw_table<B: Backend>(
         .map(|c| c.to_tui(screen_size, layout_size))
         .collect();
 
+    let pwd = app
+        .pwd
+        .strip_prefix(&app.vroot)
+        .unwrap_or(&app.pwd)
+        .trim_matches('/')
+        .replace('\\', "\\\\")
+        .replace('\n', "\\n");
+
     let table = Table::new(rows)
         .widths(&table_constraints)
         .style(app_config.general.table.style.to_owned().into())
@@ -677,8 +685,8 @@ fn draw_table<B: Backend>(
         .block(block(
             config,
             format!(
-                " {} ({}) ",
-                app.pwd.replace('\\', "\\\\").replace('\n', "\\n"),
+                " /{} ({}) ",
+                pwd,
                 app.directory_buffer
                     .as_ref()
                     .map(|d| d.total)


### PR DESCRIPTION
--vroot helps isolating navigation of an xplr session inside a specific directory. However, interaction still requires passing full paths (`/tmp/vroot`). Shell scripts and Lua functions can still access files outside the virtual root.

This PR also fixes unwanted dot (.) and extra slash (//) issues in paths.