### PR TITLE
Fix cursor position for unicode characters in input

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1376,5 +1376,6 @@ dependencies = [
  "serde_yaml",
  "tui",
  "tui-input",
+ "unicode-width",
  "which",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ fuzzy-matcher = "0.3.7"
 serde_json = "1.0.87"
 path-absolutize = "3.0.14"
 which = "4.3.0"
+unicode-width = "0.1.4"
 
 [dependencies.lazy_static]
 version = "1.4.0"


### PR DESCRIPTION
Currently cursor position is broken for characters that take more space than regular ASCII characters.
![broken](https://user-images.githubusercontent.com/2061234/201408805-2d8caf8a-3e7d-4dfe-b6bf-245d1b532310.png)

Initially i thought about fixing it in [tui-input](https://github.com/sayanarijit/tui-input), but crossterm and termion expect cursor position to match character position and providing unexpected number would make other users sad (and people that would want to use Input::with_cursor), so i brought fix here instead.

![fixed](https://user-images.githubusercontent.com/2061234/201410803-e46bf21a-c215-4a78-af30-552ac56e8445.png)

From my understanding [unicode-width](https://github.com/unicode-rs/unicode-width) is already [used by rust](https://github.com/rust-lang/rust/search?q=unicode-width), so no new dependencies are actually being introduced.
(I could be wrong)

Hit me up if something needs changes.