### PR TITLE
More UI utilities and improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1072,6 +1072,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f67ad224767faa3c7d8b6d91985b78e70a1324408abcb1cfcc2be4c06bc06043"
 
 [[package]]
+name = "snailquote"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec62a949bda7f15800481a711909f946e1204f2460f89210eaf7f57730f88f86"
+dependencies = [
+ "thiserror",
+ "unicode_categories",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1219,6 +1229,12 @@ name = "unicode-width"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+
+[[package]]
+name = "unicode_categories"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
 name = "unsafe-libyaml"
@@ -1469,6 +1485,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "snailquote",
  "textwrap",
  "tui",
  "tui-input",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ path-absolutize = "3.0.14"
 which = "4.3.0"
 nu-ansi-term = "0.46.0" 
 textwrap = "0.16"
+snailquote = "0.3.1"
 
 [dependencies.lscolors]
 version = "0.13.0"

--- a/docs/en/src/column-renderer.md
+++ b/docs/en/src/column-renderer.md
@@ -257,7 +257,7 @@ The total number of the nodes.
 
 ### style
 
-Type: mapping of string and string
+Type: [Style][39]
 
 The applicable [style object][39] for the node.
 

--- a/docs/en/src/column-renderer.md
+++ b/docs/en/src/column-renderer.md
@@ -73,6 +73,7 @@ The special argument contains the following fields
 - [is_selected][25]
 - [is_focused][26]
 - [total][27]
+- [style][38]
 - [meta][28]
 
 ### parent
@@ -254,6 +255,12 @@ Type: integer
 
 The total number of the nodes.
 
+### style
+
+Type: mapping of string and string
+
+The applicable [style object][39] for the node.
+
 ### meta
 
 Type: mapping of string and string
@@ -333,3 +340,5 @@ It contains the following fields.
 [35]: #last_modified
 [36]: #uid
 [37]: #gid
+[38]: #style
+[39]: style.md#style

--- a/docs/en/src/xplr.util.md
+++ b/docs/en/src/xplr.util.md
@@ -127,7 +127,24 @@ xplr.util.node("/")
 -- nil
 ```
 
-[5]: https://xplr.dev/en/lua-function-calls#node
+### xplr.util.node_type
+
+Get the configured [Node Type][6] of a given [Node][5].
+
+Type: function( [Node][5], [NodeTypesConfig][7]|nil ) -> [NodeType][5]
+
+If the second argument is missing, global config `xplr.config.node_types`
+will be used.
+
+Example:
+
+```lua
+xplr.util.node_type(app.focused_node)
+-- { style = { fg = ..., ... }, meta = { icon = ..., ... } ... }
+
+xplr.util.node_type(xplr.util.node("/foo/bar"), xplr.config.node_types)
+-- { style = { fg = ..., ... }, meta = { icon = ..., ... } ... }
+```
 
 ### xplr.util.dirname
 
@@ -259,9 +276,6 @@ xplr.util.explore("/tmp", app.explorer_config)
 -- { { absolute_path = "/tmp/a", ... }, ... }
 ```
 
-[1]: https://xplr.dev/en/lua-function-calls#explorer-config
-[2]: https://xplr.dev/en/lua-function-calls#node
-
 ### xplr.util.shell_execute
 
 Execute shell commands safely.
@@ -289,6 +303,19 @@ Example:
 ```lua
 xplr.util.shell_quote("a'b\"c")
 -- 'a'"'"'b"c'
+```
+
+### xplr.util.shell_escape
+
+Escape commands and paths safely.
+
+Type: function( string ) -> string
+
+Example:
+
+```lua
+xplr.util.shell_escape("a'b\"c")
+-- "\"a'b\\\"c\""
 ```
 
 ### xplr.util.from_json
@@ -353,7 +380,7 @@ xplr.util.to_yaml({ foo = "bar" })
 Get a [Style][3] object for the given path based on the LS_COLORS
 environment variable.
 
-Type: function( path:string ) -> Style[3]|nil
+Type: function( path:string ) -> [Style][3]|nil
 
 Example:
 
@@ -361,8 +388,6 @@ Example:
 xplr.util.lscolor("Desktop")
 -- { fg = "Red", bg = nil, add_modifiers = {}, sub_modifiers = {} }
 ```
-
-[3]: https://xplr.dev/en/style
 
 ### xplr.util.paint
 
@@ -375,6 +400,19 @@ Example:
 ```lua
 xplr.util.paint("Desktop", { fg = "Red", bg = nil, add_modifiers = {}, sub_modifiers = {} })
 -- "\u001b[31mDesktop\u001b[0m"
+```
+
+### xplr.util.style_mix
+
+Mix multiple [Style][3] objects into one.
+
+Type: function( [Style][3], [Style][3], ... ) -> Style[3]
+
+Example:
+
+```lua
+xplr.util.style_mix({ fg = "Red" }, { bg = "Blue" }, { add_modifiers = {"Bold"} })
+-- { fg = "Red", bg = "Blue", add_modifiers = { "Bold" }, sub_modifiers = {} }
 ```
 
 ### xplr.util.textwrap
@@ -431,4 +469,10 @@ xplr.util.layout_replace(layout, "Table", "Selection")
 -- }
 ```
 
+[1]: https://xplr.dev/en/lua-function-calls#explorer-config
+[2]: https://xplr.dev/en/lua-function-calls#node
+[3]: https://xplr.dev/en/style
 [4]: https://xplr.dev/en/layout
+[5]: https://xplr.dev/en/lua-function-calls#node
+[6]: https://xplr.dev/en/node-type
+[7]: https://xplr.dev/en/node-types

--- a/docs/script/generate.py
+++ b/docs/script/generate.py
@@ -260,6 +260,9 @@ def gen_xplr_util():
             print("\n".join(function.doc))
             print("\n".join(function.doc), file=f)
 
+        if reading:
+            print("\n".join(reading.doc), file=f)
+
 
 def format_docs():
     os.system("prettier --write docs/en/src")

--- a/src/init.lua
+++ b/src/init.lua
@@ -2620,6 +2620,7 @@ xplr.fn.builtin.try_complete_path = function(m)
 end
 
 xplr.fn.builtin.fmt_general_selection_item = function(n)
+  local nl = xplr.util.paint("\\n", { add_modifiers = { "Italic", "Dim" } })
   local sh_config = { with_prefix_dots = true, without_suffix_dots = true }
   local shortened = xplr.util.shorten(n.absolute_path, sh_config)
   if n.is_dir then
@@ -2628,7 +2629,7 @@ xplr.fn.builtin.fmt_general_selection_item = function(n)
   local ls_style = xplr.util.lscolor(n.absolute_path)
   local meta_style = xplr.util.node_type(n).style
   local style = xplr.util.style_mix({ meta_style, ls_style })
-  return xplr.util.paint(xplr.util.shell_escape(shortened), style)
+  return xplr.util.paint(shortened:gsub("\n", nl), style)
 end
 
 -- Renders the first column in the table
@@ -2647,8 +2648,8 @@ end
 
 -- Renders the second column in the table
 xplr.fn.builtin.fmt_general_table_row_cols_1 = function(m)
+  local nl = xplr.util.paint("\\n", { add_modifiers = { "Italic", "Dim" } })
   local r = m.tree .. m.prefix
-
   local style = xplr.util.lscolor(m.absolute_path)
   style = xplr.util.style_mix({ m.style, style })
 
@@ -2676,7 +2677,7 @@ xplr.fn.builtin.fmt_general_table_row_cols_1 = function(m)
       if m.symlink.is_dir then
         symlink_path = symlink_path .. "/"
       end
-      r = r .. xplr.util.shell_escape(symlink_path)
+      r = r .. symlink_path:gsub("\n", nl)
     end
   end
 

--- a/src/path.rs
+++ b/src/path.rs
@@ -1,6 +1,7 @@
 use anyhow::{bail, Result};
 use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
+pub use snailquote::escape;
 use std::path::{Component, Path, PathBuf};
 
 lazy_static! {
@@ -469,5 +470,26 @@ mod tests {
         )
         .unwrap();
         assert_eq!(res, "/");
+    }
+
+    #[test]
+    fn test_path_escape() {
+        let text = "foo".to_string();
+        assert_eq!(escape(&text), "foo");
+
+        let text = "foo bar".to_string();
+        assert_eq!(escape(&text), "'foo bar'");
+
+        let text = "foo\nbar".to_string();
+        assert_eq!(escape(&text), "\"foo\\nbar\"");
+
+        let text = "foo$bar".to_string();
+        assert_eq!(escape(&text), "'foo$bar'");
+
+        let text = "foo'$\n'bar".to_string();
+        assert_eq!(escape(&text), "\"foo'\\$\\n'bar\"");
+
+        let text = "a'b\"c".to_string();
+        assert_eq!(escape(&text), "\"a'b\\\"c\"");
     }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -804,7 +804,7 @@ fn draw_table<B: Backend>(
     }
     .trim_matches('/');
 
-    let pwd = path::escape(&pwd);
+    let pwd = path::escape(pwd);
 
     let vroot_indicator = if app.vroot.is_some() { "vroot:" } else { "" };
 
@@ -1541,7 +1541,11 @@ mod tests {
             Style {
                 fg: Some(Color::Cyan),
                 bg: Some(Color::Magenta),
-                add_modifiers: modifier(Modifier::CrossedOut),
+                add_modifiers: Some(
+                    vec![Modifier::Bold, Modifier::CrossedOut]
+                        .into_iter()
+                        .collect()
+                ),
                 sub_modifiers: modifier(Modifier::Italic),
             }
         );
@@ -1551,7 +1555,11 @@ mod tests {
             Style {
                 fg: Some(Color::Red),
                 bg: Some(Color::Magenta),
-                add_modifiers: modifier(Modifier::Bold),
+                add_modifiers: Some(
+                    vec![Modifier::Bold, Modifier::CrossedOut]
+                        .into_iter()
+                        .collect()
+                ),
                 sub_modifiers: modifier(Modifier::Italic),
             }
         );


### PR DESCRIPTION
- Apply style only to the file column in the table.
- Properly quote paths.
- Expose the applicable style from config in the table renderer argument.
- Add utility functions:
  - xplr.util.node_type
  - xplr.util.style_mix
  - xplr.util.shell_escape