### PR TITLE
Fix typos

### DIFF
--- a/docs/en/src/awesome-hacks.md
+++ b/docs/en/src/awesome-hacks.md
@@ -8,7 +8,7 @@ Do you have something cool to share?
 
 [Edit this file][3] or [share them here][4] or [let us know][5].
 
-You can try these hacks by writing them to a file, say `hack.lua` and passsing
+You can try these hacks by writing them to a file, say `hack.lua` and passing
 it to xplr with `--extra-config` or `-C`.
 
 ```bash

--- a/docs/en/src/awesome-plugins.md
+++ b/docs/en/src/awesome-plugins.md
@@ -11,7 +11,7 @@ of the following plugins work for you, it's very easy to
 - [**sayanarijit/dual-pane.xplr**][43] Implements support for dual-pane navigation into xplr.
 - [**sayanarijit/map.xplr**][38] Visually inspect and interactively execute batch commands using xplr.
 - [**sayanarijit/offline-docs.xplr**][51] Fetch the appropriate version of xplr docs and browse offline.
-- [**sayanarijit/regex-search.xplr**][55] Bring back the regex based seach in xplr.
+- [**sayanarijit/regex-search.xplr**][55] Bring back the regex based search in xplr.
 - [**sayanarijit/registers.xplr**][49] Use multiple registers to store the selected paths.
 - [**sayanarijit/tri-pane.xplr**][56] xplr plugin that implements ranger-like three pane layout.
 - [**sayanarijit/type-to-nav.xplr**][28] Inspired by [nnn's type-to-nav mode][29] for xplr,

--- a/docs/en/src/general-config.md
+++ b/docs/en/src/general-config.md
@@ -72,7 +72,7 @@ Type: nullable string
 
 #### xplr.config.general.logs.info.style
 
-The style for the informations logs.
+The style for the information logs.
 
 Type: [Style](https://xplr.dev/en/style)
 

--- a/docs/en/src/layout.md
+++ b/docs/en/src/layout.md
@@ -349,7 +349,7 @@ This is a lightweight version of the [Lua Context][39]. In this context, the
 heavyweight fields like [directory_buffer][50] are omitted for performance
 reasons.
 
-Hence, only the following fields are avilable.
+Hence, only the following fields are available.
 
 - [version][40]
 - [pwd][41]

--- a/docs/en/src/lua-function-calls.md
+++ b/docs/en/src/lua-function-calls.md
@@ -372,7 +372,7 @@ The searcher to use (if any).
 
 Type: nullable [Node Searcher Applicable][82]
 
-## Also Ssee:
+## Also See:
 
 - [xplr.util][85]
 

--- a/docs/en/src/messages.md
+++ b/docs/en/src/messages.md
@@ -389,7 +389,7 @@ Example:
 
 Update the input buffer using cursor based operations.
 
-Type: { UpdateInputBuffer = [Input Opertaion](https://xplr.dev/en/input-operation) }
+Type: { UpdateInputBuffer = [Input Operation](https://xplr.dev/en/input-operation) }
 
 Example:
 
@@ -418,7 +418,7 @@ Example:
 
 #### BufferInputFromKey
 
-Append/buffer the characted read from a keyboard input into the
+Append/buffer the character read from a keyboard input into the
 input buffer.
 
 Example:
@@ -843,7 +843,7 @@ Example:
 
 Add a [filter](https://xplr.dev/en/filtering#filter) to exclude nodes
 while exploring directories.
-You need to call `ExplorePwd` or `ExplorePwdAsync` explicitely.
+You need to call `ExplorePwd` or `ExplorePwdAsync` explicitly.
 Filters get automatically cleared when changing directories.
 
 Type: { AddNodeFilter = { filter = [Filter](https://xplr.dev/en/filtering#filter), input = "string" }
@@ -856,7 +856,7 @@ Example:
 #### RemoveNodeFilter
 
 Remove an existing [filter](https://xplr.dev/en/filtering#filter).
-You need to call `ExplorePwd` or `ExplorePwdAsync` explicitely.
+You need to call `ExplorePwd` or `ExplorePwdAsync` explicitly.
 
 Type: { RemoveNodeFilter = { filter = [Filter](https://xplr.dev/en/filtering), input = "string" }
 
@@ -869,7 +869,7 @@ Example:
 
 Remove a [filter](https://xplr.dev/en/filtering#filter) if it exists,
 else, add a it.
-You need to call `ExplorePwd` or `ExplorePwdAsync` explicitely.
+You need to call `ExplorePwd` or `ExplorePwdAsync` explicitly.
 
 Type: { ToggleNodeFilter = { filter = [Filter](https://xplr.dev/en/filtering), input = "string" }
 
@@ -882,7 +882,7 @@ Example:
 
 Add a node [filter](https://xplr.dev/en/filtering#filter) reading the
 input from the buffer.
-You need to call `ExplorePwd` or `ExplorePwdAsync` explicitely.
+You need to call `ExplorePwd` or `ExplorePwdAsync` explicitly.
 
 Type: { AddNodeFilterFromInput = [Filter](https://xplr.dev/en/filtering) }
 
@@ -895,7 +895,7 @@ Example:
 
 Remove a node [filter](https://xplr.dev/en/filtering#filter) reading
 the input from the buffer.
-You need to call `ExplorePwd` or `ExplorePwdAsync` explicitely.
+You need to call `ExplorePwd` or `ExplorePwdAsync` explicitly.
 
 Type: { RemoveNodeFilterFromInput = [Filter](https://xplr.dev/en/filtering) }
 
@@ -907,7 +907,7 @@ Example:
 #### RemoveLastNodeFilter
 
 Remove the last node [filter](https://xplr.dev/en/filtering).
-You need to call `ExplorePwd` or `ExplorePwdAsync` explicitely.
+You need to call `ExplorePwd` or `ExplorePwdAsync` explicitly.
 
 Example:
 
@@ -918,7 +918,7 @@ Example:
 
 Reset the node [filters](https://xplr.dev/en/filtering) back to the
 default configuration.
-You need to call `ExplorePwd` or `ExplorePwdAsync` explicitely.
+You need to call `ExplorePwd` or `ExplorePwdAsync` explicitly.
 
 Example:
 
@@ -928,7 +928,7 @@ Example:
 #### ClearNodeFilters
 
 Clear all the node [filters](https://xplr.dev/en/filtering).
-You need to call `ExplorePwd` or `ExplorePwdAsync` explicitely.
+You need to call `ExplorePwd` or `ExplorePwdAsync` explicitly.
 
 Example:
 
@@ -941,7 +941,7 @@ Example:
 
 Add a [sorter](https://xplr.dev/en/sorting#sorter) to sort nodes while
 exploring directories.
-You need to call `ExplorePwd` or `ExplorePwdAsync` explicitely.
+You need to call `ExplorePwd` or `ExplorePwdAsync` explicitly.
 
 Type: { AddNodeSorter = { sorter = [Sorter](https://xplr.dev/en/sorting#sorter), reverse = bool } }
 
@@ -953,7 +953,7 @@ Example:
 #### RemoveNodeSorter
 
 Remove an existing [sorter](https://xplr.dev/en/sorting#sorter).
-You need to call `ExplorePwd` or `ExplorePwdAsync` explicitely.
+You need to call `ExplorePwd` or `ExplorePwdAsync` explicitly.
 
 Type: { RemoveNodeSorter = [Sorter](https://xplr.dev/en/sorting#sorter) }
 
@@ -965,7 +965,7 @@ Example:
 #### ReverseNodeSorter
 
 Reverse a node [sorter](https://xplr.dev/en/sorting#sorter).
-You need to call `ExplorePwd` or `ExplorePwdAsync` explicitely.
+You need to call `ExplorePwd` or `ExplorePwdAsync` explicitly.
 
 Type: { ReverseNodeSorter = [Sorter](https://xplr.dev/en/sorting#sorter) }
 
@@ -978,7 +978,7 @@ Example:
 
 Remove a [sorter](https://xplr.dev/en/sorting#sorter) if it exists,
 else, add a it.
-You need to call `ExplorePwd` or `ExplorePwdAsync` explicitely.
+You need to call `ExplorePwd` or `ExplorePwdAsync` explicitly.
 
 Type: { ToggleNodeSorter = { sorter = [Sorter](https://xplr.dev/en/sorting#sorter), reverse = bool } }
 
@@ -990,7 +990,7 @@ Example:
 #### ReverseNodeSorters
 
 Reverse the node [sorters](https://xplr.dev/en/sorting#sorter).
-You need to call `ExplorePwd` or `ExplorePwdAsync` explicitely.
+You need to call `ExplorePwd` or `ExplorePwdAsync` explicitly.
 
 Example:
 
@@ -1000,7 +1000,7 @@ Example:
 #### RemoveLastNodeSorter
 
 Remove the last node [sorter](https://xplr.dev/en/sorting#sorter).
-You need to call `ExplorePwd` or `ExplorePwdAsync` explicitely.
+You need to call `ExplorePwd` or `ExplorePwdAsync` explicitly.
 
 Example:
 
@@ -1011,7 +1011,7 @@ Example:
 
 Reset the node [sorters](https://xplr.dev/en/sorting#sorter) back to
 the default configuration.
-You need to call `ExplorePwd` or `ExplorePwdAsync` explicitely.
+You need to call `ExplorePwd` or `ExplorePwdAsync` explicitly.
 
 Example:
 
@@ -1021,7 +1021,7 @@ Example:
 #### ClearNodeSorters
 
 Clear all the node [sorters](https://xplr.dev/en/sorting#sorter).
-You need to call `ExplorePwd` or `ExplorePwdAsync` explicitely.
+You need to call `ExplorePwd` or `ExplorePwdAsync` explicitly.
 
 Example:
 
@@ -1033,7 +1033,7 @@ Example:
 #### Search
 
 Search files using the current or default (fuzzy) search algorithm.
-You need to call `ExplorePwd` or `ExplorePwdAsync` explicitely.
+You need to call `ExplorePwd` or `ExplorePwdAsync` explicitly.
 It gets reset automatically when changing directory.
 
 Type: { Search = "string" }
@@ -1056,7 +1056,7 @@ Example:
 
 Search files using fuzzy match algorithm.
 It keeps the filters, but overrides the sorters.
-You need to call `ExplorePwd` or `ExplorePwdAsync` explicitely.
+You need to call `ExplorePwd` or `ExplorePwdAsync` explicitly.
 It gets reset automatically when changing directory.
 
 Type: { SearchFuzzy = "string" }
@@ -1069,7 +1069,7 @@ Example:
 #### SearchFuzzyFromInput
 
 Calls `SearchFuzzy` with the input taken from the input buffer.
-You need to call `ExplorePwd` or `ExplorePwdAsync` explicitely.
+You need to call `ExplorePwd` or `ExplorePwdAsync` explicitly.
 It gets reset automatically when changing directory.
 
 Example:
@@ -1080,7 +1080,7 @@ Example:
 #### SearchFuzzyUnordered
 
 Like `SearchFuzzy`, but doesn't not perform rank based sorting.
-You need to call `ExplorePwd` or `ExplorePwdAsync` explicitely.
+You need to call `ExplorePwd` or `ExplorePwdAsync` explicitly.
 It gets reset automatically when changing directory.
 
 Type: { SearchFuzzyUnordered = "string" }
@@ -1093,7 +1093,7 @@ Example:
 #### SearchFuzzyUnorderedFromInput
 
 Calls `SearchFuzzyUnordered` with the input taken from the input buffer.
-You need to call `ExplorePwd` or `ExplorePwdAsync` explicitely.
+You need to call `ExplorePwd` or `ExplorePwdAsync` explicitly.
 It gets reset automatically when changing directory.
 
 Example:
@@ -1105,7 +1105,7 @@ Example:
 
 Search files using regex match algorithm.
 It keeps the filters, but overrides the sorters.
-You need to call `ExplorePwd` or `ExplorePwdAsync` explicitely.
+You need to call `ExplorePwd` or `ExplorePwdAsync` explicitly.
 It gets reset automatically when changing directory.
 
 Type: { SearchRegex = "string" }
@@ -1118,7 +1118,7 @@ Example:
 #### SearchRegexFromInput
 
 Calls `SearchRegex` with the input taken from the input buffer.
-You need to call `ExplorePwd` or `ExplorePwdAsync` explicitely.
+You need to call `ExplorePwd` or `ExplorePwdAsync` explicitly.
 It gets reset automatically when changing directory.
 
 Example:
@@ -1129,7 +1129,7 @@ Example:
 #### SearchRegexUnordered
 
 Like `SearchRegex`, but doesn't not perform rank based sorting.
-You need to call `ExplorePwd` or `ExplorePwdAsync` explicitely.
+You need to call `ExplorePwd` or `ExplorePwdAsync` explicitly.
 It gets reset automatically when changing directory.
 
 Type: { SearchRegexUnordered = "string" }
@@ -1142,7 +1142,7 @@ Example:
 #### SearchRegexUnorderedFromInput
 
 Calls `SearchRegexUnordered` with the input taken from the input buffer.
-You need to call `ExplorePwd` or `ExplorePwdAsync` explicitely.
+You need to call `ExplorePwd` or `ExplorePwdAsync` explicitly.
 It gets reset automatically when changing directory.
 
 Example:
@@ -1154,7 +1154,7 @@ Example:
 
 Toggles between different search algorithms, without changing the input
 buffer
-You need to call `ExplorePwd` or `ExplorePwdAsync` explicitely.
+You need to call `ExplorePwd` or `ExplorePwdAsync` explicitly.
 
 Example:
 
@@ -1164,7 +1164,7 @@ Example:
 #### EnableSearchOrder
 
 Enables ranked search without changing the input buffer.
-You need to call `ExplorePwd` or `ExplorePwdAsync` explicitely.
+You need to call `ExplorePwd` or `ExplorePwdAsync` explicitly.
 
 Example:
 
@@ -1174,7 +1174,7 @@ Example:
 #### DisableSearchOrder
 
 Disabled ranked search without changing the input buffer.
-You need to call `ExplorePwd` or `ExplorePwdAsync` explicitely.
+You need to call `ExplorePwd` or `ExplorePwdAsync` explicitly.
 
 Example:
 
@@ -1264,7 +1264,7 @@ Example:
 
 #### ToggleFifo
 
-Toggle betwen {Start|Stop}Fifo
+Toggle between {Start|Stop}Fifo
 
 Type: { ToggleFifo = "string" }
 

--- a/docs/en/src/searching.md
+++ b/docs/en/src/searching.md
@@ -24,7 +24,7 @@ Node Searcher contains the following fields:
 
 ### pattern
 
-The patters used to search.
+The patterns used to search.
 
 Type: string
 

--- a/docs/en/src/upgrade-guide.md
+++ b/docs/en/src/upgrade-guide.md
@@ -98,7 +98,7 @@ compatibility.
   rendered:
   - xplr.config.general.selection.item.format
   - xplr.config.general.selection.item.style
-- Use the following utility functions to work with teh file permissions:
+- Use the following utility functions to work with the file permissions:
   - xplr.util.permissions_rwx
   - xplr.util.permissions_octal
 - Type `:p` to edit file permissions interactively.
@@ -305,7 +305,7 @@ Thanks to @noahmayr for contributing to a major part of this release.
 - You can disable the recover mode using `config.general.disable_recover_mode = true`.
 - Try running `xplr --help`. Yes, CLI has been implemented.
 - Since version `v0.14.3`, `StartFifo` and `ToggleFifo` will write to the FIFO
-  path when called. So, there's no need to pipe the focus path explicitely.
+  path when called. So, there's no need to pipe the focus path explicitly.
 - Since version `v0.14.3`, general config `xplr.config.start_fifo` is available
   which can be set to a file path to start a fifo when xplr starts.
 - Since version `v0.14.4`, `$XPLR_SESSION_PATH` can be used to dump session
@@ -316,7 +316,7 @@ Thanks to @noahmayr for contributing to a major part of this release.
 #### [v0.12.1][6] -> [v0.13.7][2]
 
 - Lua functions called using [`CallLua`][7] and [`CallLuaSilently`][8] messages will receive [`CallLuaArg`][9] object as the function argument (instead of the [`App`][10] object).
-- Each `node_types` config will inherit defaults from matching less specifig `node_types` config and overwrite them.
+- Each `node_types` config will inherit defaults from matching less specific `node_types` config and overwrite them.
 - Since version `v0.13.2`, you don't need to use/send `Refresh` anymore. It will be auto-handled by xplr.
 
 #### [v0.11.1][11] -> [v0.12.1][6]

--- a/src/init.lua
+++ b/src/init.lua
@@ -115,7 +115,7 @@ xplr.config.general.prompt.style = {}
 -- Type: nullable string
 xplr.config.general.logs.info.format = "INFO"
 
--- The style for the informations logs.
+-- The style for the information logs.
 --
 -- Type: [Style](https://xplr.dev/en/style)
 xplr.config.general.logs.info.style = { fg = "LightBlue" }

--- a/src/msg/in_/external.rs
+++ b/src/msg/in_/external.rs
@@ -338,7 +338,7 @@ pub enum ExternalMsg {
 
     /// Update the input buffer using cursor based operations.
     ///
-    /// Type: { UpdateInputBuffer = [Input Opertaion](https://xplr.dev/en/input-operation) }
+    /// Type: { UpdateInputBuffer = [Input Operation](https://xplr.dev/en/input-operation) }
     ///
     /// Example:
     ///
@@ -364,7 +364,7 @@ pub enum ExternalMsg {
     /// - YAML: `BufferInput: foo`
     BufferInput(String),
 
-    /// Append/buffer the characted read from a keyboard input into the
+    /// Append/buffer the character read from a keyboard input into the
     /// input buffer.
     ///
     /// Example:
@@ -751,7 +751,7 @@ pub enum ExternalMsg {
 
     /// Add a [filter](https://xplr.dev/en/filtering#filter) to exclude nodes
     /// while exploring directories.
-    /// You need to call `ExplorePwd` or `ExplorePwdAsync` explicitely.
+    /// You need to call `ExplorePwd` or `ExplorePwdAsync` explicitly.
     /// Filters get automatically cleared when changing directories.
     ///
     /// Type: { AddNodeFilter = { filter = [Filter](https://xplr.dev/en/filtering#filter), input = "string" }
@@ -763,7 +763,7 @@ pub enum ExternalMsg {
     AddNodeFilter(NodeFilterApplicable),
 
     /// Remove an existing [filter](https://xplr.dev/en/filtering#filter).
-    /// You need to call `ExplorePwd` or `ExplorePwdAsync` explicitely.
+    /// You need to call `ExplorePwd` or `ExplorePwdAsync` explicitly.
     ///
     /// Type: { RemoveNodeFilter = { filter = [Filter](https://xplr.dev/en/filtering), input = "string" }
     ///
@@ -775,7 +775,7 @@ pub enum ExternalMsg {
 
     /// Remove a [filter](https://xplr.dev/en/filtering#filter) if it exists,
     /// else, add a it.
-    /// You need to call `ExplorePwd` or `ExplorePwdAsync` explicitely.
+    /// You need to call `ExplorePwd` or `ExplorePwdAsync` explicitly.
     ///
     /// Type: { ToggleNodeFilter = { filter = [Filter](https://xplr.dev/en/filtering), input = "string" }
     ///
@@ -787,7 +787,7 @@ pub enum ExternalMsg {
 
     /// Add a node [filter](https://xplr.dev/en/filtering#filter) reading the
     /// input from the buffer.
-    /// You need to call `ExplorePwd` or `ExplorePwdAsync` explicitely.
+    /// You need to call `ExplorePwd` or `ExplorePwdAsync` explicitly.
     ///
     /// Type: { AddNodeFilterFromInput = [Filter](https://xplr.dev/en/filtering) }
     ///
@@ -799,7 +799,7 @@ pub enum ExternalMsg {
 
     /// Remove a node [filter](https://xplr.dev/en/filtering#filter) reading
     /// the input from the buffer.
-    /// You need to call `ExplorePwd` or `ExplorePwdAsync` explicitely.
+    /// You need to call `ExplorePwd` or `ExplorePwdAsync` explicitly.
     ///
     /// Type: { RemoveNodeFilterFromInput = [Filter](https://xplr.dev/en/filtering) }
     ///
@@ -810,7 +810,7 @@ pub enum ExternalMsg {
     RemoveNodeFilterFromInput(NodeFilter),
 
     /// Remove the last node [filter](https://xplr.dev/en/filtering).
-    /// You need to call `ExplorePwd` or `ExplorePwdAsync` explicitely.
+    /// You need to call `ExplorePwd` or `ExplorePwdAsync` explicitly.
     ///
     /// Example:
     ///
@@ -820,7 +820,7 @@ pub enum ExternalMsg {
 
     /// Reset the node [filters](https://xplr.dev/en/filtering) back to the
     /// default configuration.
-    /// You need to call `ExplorePwd` or `ExplorePwdAsync` explicitely.
+    /// You need to call `ExplorePwd` or `ExplorePwdAsync` explicitly.
     ///
     /// Example:
     ///
@@ -829,7 +829,7 @@ pub enum ExternalMsg {
     ResetNodeFilters,
 
     /// Clear all the node [filters](https://xplr.dev/en/filtering).
-    /// You need to call `ExplorePwd` or `ExplorePwdAsync` explicitely.
+    /// You need to call `ExplorePwd` or `ExplorePwdAsync` explicitly.
     ///
     /// Example:
     ///
@@ -841,7 +841,7 @@ pub enum ExternalMsg {
 
     /// Add a [sorter](https://xplr.dev/en/sorting#sorter) to sort nodes while
     /// exploring directories.
-    /// You need to call `ExplorePwd` or `ExplorePwdAsync` explicitely.
+    /// You need to call `ExplorePwd` or `ExplorePwdAsync` explicitly.
     ///
     /// Type: { AddNodeSorter = { sorter = [Sorter](https://xplr.dev/en/sorting#sorter), reverse = bool } }
     ///
@@ -852,7 +852,7 @@ pub enum ExternalMsg {
     AddNodeSorter(NodeSorterApplicable),
 
     /// Remove an existing [sorter](https://xplr.dev/en/sorting#sorter).
-    /// You need to call `ExplorePwd` or `ExplorePwdAsync` explicitely.
+    /// You need to call `ExplorePwd` or `ExplorePwdAsync` explicitly.
     ///
     /// Type: { RemoveNodeSorter = [Sorter](https://xplr.dev/en/sorting#sorter) }
     ///
@@ -863,7 +863,7 @@ pub enum ExternalMsg {
     RemoveNodeSorter(NodeSorter),
 
     /// Reverse a node [sorter](https://xplr.dev/en/sorting#sorter).
-    /// You need to call `ExplorePwd` or `ExplorePwdAsync` explicitely.
+    /// You need to call `ExplorePwd` or `ExplorePwdAsync` explicitly.
     ///
     /// Type: { ReverseNodeSorter = [Sorter](https://xplr.dev/en/sorting#sorter) }
     ///
@@ -875,7 +875,7 @@ pub enum ExternalMsg {
 
     /// Remove a [sorter](https://xplr.dev/en/sorting#sorter) if it exists,
     /// else, add a it.
-    /// You need to call `ExplorePwd` or `ExplorePwdAsync` explicitely.
+    /// You need to call `ExplorePwd` or `ExplorePwdAsync` explicitly.
     ///
     /// Type: { ToggleNodeSorter = { sorter = [Sorter](https://xplr.dev/en/sorting#sorter), reverse = bool } }
     ///
@@ -886,7 +886,7 @@ pub enum ExternalMsg {
     ToggleNodeSorter(NodeSorterApplicable),
 
     /// Reverse the node [sorters](https://xplr.dev/en/sorting#sorter).
-    /// You need to call `ExplorePwd` or `ExplorePwdAsync` explicitely.
+    /// You need to call `ExplorePwd` or `ExplorePwdAsync` explicitly.
     ///
     /// Example:
     ///
@@ -895,7 +895,7 @@ pub enum ExternalMsg {
     ReverseNodeSorters,
 
     /// Remove the last node [sorter](https://xplr.dev/en/sorting#sorter).
-    /// You need to call `ExplorePwd` or `ExplorePwdAsync` explicitely.
+    /// You need to call `ExplorePwd` or `ExplorePwdAsync` explicitly.
     ///
     /// Example:
     ///
@@ -905,7 +905,7 @@ pub enum ExternalMsg {
 
     /// Reset the node [sorters](https://xplr.dev/en/sorting#sorter) back to
     /// the default configuration.
-    /// You need to call `ExplorePwd` or `ExplorePwdAsync` explicitely.
+    /// You need to call `ExplorePwd` or `ExplorePwdAsync` explicitly.
     ///
     /// Example:
     ///
@@ -914,7 +914,7 @@ pub enum ExternalMsg {
     ResetNodeSorters,
 
     /// Clear all the node [sorters](https://xplr.dev/en/sorting#sorter).
-    /// You need to call `ExplorePwd` or `ExplorePwdAsync` explicitely.
+    /// You need to call `ExplorePwd` or `ExplorePwdAsync` explicitly.
     ///
     /// Example:
     ///
@@ -925,7 +925,7 @@ pub enum ExternalMsg {
     /// ### Search Operations --------------------------------------------------
 
     /// Search files using the current or default (fuzzy) search algorithm.
-    /// You need to call `ExplorePwd` or `ExplorePwdAsync` explicitely.
+    /// You need to call `ExplorePwd` or `ExplorePwdAsync` explicitly.
     /// It gets reset automatically when changing directory.
     ///
     /// Type: { Search = "string" }
@@ -946,7 +946,7 @@ pub enum ExternalMsg {
 
     /// Search files using fuzzy match algorithm.
     /// It keeps the filters, but overrides the sorters.
-    /// You need to call `ExplorePwd` or `ExplorePwdAsync` explicitely.
+    /// You need to call `ExplorePwd` or `ExplorePwdAsync` explicitly.
     /// It gets reset automatically when changing directory.
     ///
     /// Type: { SearchFuzzy = "string" }
@@ -958,7 +958,7 @@ pub enum ExternalMsg {
     SearchFuzzy(String),
 
     /// Calls `SearchFuzzy` with the input taken from the input buffer.
-    /// You need to call `ExplorePwd` or `ExplorePwdAsync` explicitely.
+    /// You need to call `ExplorePwd` or `ExplorePwdAsync` explicitly.
     /// It gets reset automatically when changing directory.
     ///
     /// Example:
@@ -968,7 +968,7 @@ pub enum ExternalMsg {
     SearchFuzzyFromInput,
 
     /// Like `SearchFuzzy`, but doesn't not perform rank based sorting.
-    /// You need to call `ExplorePwd` or `ExplorePwdAsync` explicitely.
+    /// You need to call `ExplorePwd` or `ExplorePwdAsync` explicitly.
     /// It gets reset automatically when changing directory.
     ///
     /// Type: { SearchFuzzyUnordered = "string" }
@@ -980,7 +980,7 @@ pub enum ExternalMsg {
     SearchFuzzyUnordered(String),
 
     /// Calls `SearchFuzzyUnordered` with the input taken from the input buffer.
-    /// You need to call `ExplorePwd` or `ExplorePwdAsync` explicitely.
+    /// You need to call `ExplorePwd` or `ExplorePwdAsync` explicitly.
     /// It gets reset automatically when changing directory.
     ///
     /// Example:
@@ -991,7 +991,7 @@ pub enum ExternalMsg {
 
     /// Search files using regex match algorithm.
     /// It keeps the filters, but overrides the sorters.
-    /// You need to call `ExplorePwd` or `ExplorePwdAsync` explicitely.
+    /// You need to call `ExplorePwd` or `ExplorePwdAsync` explicitly.
     /// It gets reset automatically when changing directory.
     ///
     /// Type: { SearchRegex = "string" }
@@ -1003,7 +1003,7 @@ pub enum ExternalMsg {
     SearchRegex(String),
 
     /// Calls `SearchRegex` with the input taken from the input buffer.
-    /// You need to call `ExplorePwd` or `ExplorePwdAsync` explicitely.
+    /// You need to call `ExplorePwd` or `ExplorePwdAsync` explicitly.
     /// It gets reset automatically when changing directory.
     ///
     /// Example:
@@ -1013,7 +1013,7 @@ pub enum ExternalMsg {
     SearchRegexFromInput,
 
     /// Like `SearchRegex`, but doesn't not perform rank based sorting.
-    /// You need to call `ExplorePwd` or `ExplorePwdAsync` explicitely.
+    /// You need to call `ExplorePwd` or `ExplorePwdAsync` explicitly.
     /// It gets reset automatically when changing directory.
     ///
     /// Type: { SearchRegexUnordered = "string" }
@@ -1025,7 +1025,7 @@ pub enum ExternalMsg {
     SearchRegexUnordered(String),
 
     /// Calls `SearchRegexUnordered` with the input taken from the input buffer.
-    /// You need to call `ExplorePwd` or `ExplorePwdAsync` explicitely.
+    /// You need to call `ExplorePwd` or `ExplorePwdAsync` explicitly.
     /// It gets reset automatically when changing directory.
     ///
     /// Example:
@@ -1036,7 +1036,7 @@ pub enum ExternalMsg {
 
     /// Toggles between different search algorithms, without changing the input
     /// buffer
-    /// You need to call `ExplorePwd` or `ExplorePwdAsync` explicitely.
+    /// You need to call `ExplorePwd` or `ExplorePwdAsync` explicitly.
     ///
     /// Example:
     ///
@@ -1045,7 +1045,7 @@ pub enum ExternalMsg {
     ToggleSearchAlgorithm,
 
     /// Enables ranked search without changing the input buffer.
-    /// You need to call `ExplorePwd` or `ExplorePwdAsync` explicitely.
+    /// You need to call `ExplorePwd` or `ExplorePwdAsync` explicitly.
     ///
     /// Example:
     ///
@@ -1054,7 +1054,7 @@ pub enum ExternalMsg {
     EnableSearchOrder,
 
     /// Disabled ranked search without changing the input buffer.
-    /// You need to call `ExplorePwd` or `ExplorePwdAsync` explicitely.
+    /// You need to call `ExplorePwd` or `ExplorePwdAsync` explicitly.
     ///
     /// Example:
     ///
@@ -1135,7 +1135,7 @@ pub enum ExternalMsg {
     /// - YAML: `StopFifo`
     StopFifo,
 
-    /// Toggle betwen {Start|Stop}Fifo
+    /// Toggle between {Start|Stop}Fifo
     ///
     /// Type: { ToggleFifo = "string" }
     ///


### PR DESCRIPTION
Found via `codespell -S target -L ratatui,crate,ser,enque,noice`