### PR TITLE
docs: add missing comma to node_types lua conf

### DIFF
--- a/docs/en/src/node_types.md
+++ b/docs/en/src/node_types.md
@@ -88,7 +88,7 @@ Example:
 xplr.config.node_types.mime_essence = {
   application = {
     -- application/*
-    ["*"] = { meta = { icon = "a" } }
+    ["*"] = { meta = { icon = "a" } },
 
     -- application/pdf
     pdf = { meta = { icon = "" }, style = { fg = "Blue" } },


### PR DESCRIPTION
Add missing comma to node_types lua conf example in the docs.