### PR TITLE
Allow nesting layouts inside a custom layout

### DIFF
--- a/docs/en/src/layout.md
+++ b/docs/en/src/layout.md
@@ -178,6 +178,7 @@ Custom panel can be one of the following:
 - [CustomParagraph][29]
 - [CustomList][30]
 - [CustomTable][31]
+- [CustomLayout][55]
 
 ### CustomParagraph
 
@@ -308,6 +309,44 @@ xplr.fn.custom.render_layout = function(ctx)
 end
 ```
 
+### CustomLayout
+
+A whole custom layout to render. It doesn't make sense to use it as a
+[Static][25] layout, but can be very useful to render as a [Dynamic][26] layout
+for use cases where the structure of the layout needs to change without having
+to switch modes.
+
+> WARNING: Rendering the same dynamic custom layout recursively will result in
+> a ugly crash.
+
+#### Example: Render a custom dynamic layout
+
+```lua
+xplr.config.layouts.builtin.default = { Dynamic = "custom.render_layout" }
+
+xplr.fn.custom.render_layout = function(ctx)
+  local inner = {
+    config = {
+      constraints = {
+        { Percentage = 50 },
+        { Percentage = 50 },
+      },
+    },
+    splits = {
+      { Static = { CustomParagraph = { body = "Try your luck..." } } },
+      { Static = { CustomParagraph = { body = "Press ctrl-r" } } },
+    },
+  }
+
+  local layout_type = "Vertical"
+  if math.random(1, 2) == 1 then
+    layout_type = "Horizontal"
+  end
+
+  return { CustomLayout = { [layout_type] = inner } }
+end
+```
+
 ## Panel UI Config
 
 It contains the following optional fields:
@@ -422,3 +461,4 @@ Hence, only the following fields are available.
 [52]: lua-function-calls.md#vroot
 [53]: lua-function-calls.md#initial_pwd
 [54]: borders.md#border-type
+[55]: #customlayout

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -97,6 +97,7 @@ pub enum CustomPanel {
         col_spacing: Option<u16>,
         body: Vec<Vec<String>>,
     },
+    CustomLayout(Layout),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -1291,6 +1292,10 @@ pub fn draw_static<B: Backend>(
                 .block(block(config, "".into()));
 
             f.render_widget(content, layout_size);
+        }
+
+        CustomPanel::CustomLayout(layout) => {
+            draw_layout(layout, f, screen_size, layout_size, app, _lua);
         }
     }
 }


### PR DESCRIPTION
This adds `CustomLayout` panel for nesting a `Layout` inside the `Static` and `Dynamic` layouts.

This will help switching between different layouts dynamically, without having to switch modes.