### PR TITLE
Use xdg-rust crate instead of dirs crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -441,15 +441,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
-name = "dirs"
-version = "5.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
 name = "dirs-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -457,18 +448,6 @@ checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
  "cfg-if",
  "dirs-sys-next",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
-dependencies = [
- "libc",
- "option-ext",
- "redox_users",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -570,6 +549,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "home"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
+dependencies = [
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -894,12 +882,6 @@ name = "oorandom"
 version = "11.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
-
-[[package]]
-name = "option-ext"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "os_str_bytes"
@@ -1798,6 +1780,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
+name = "xdg"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "688597db5a750e9cad4511cb94729a078e274308099a0382b5b8203bbc767fee"
+dependencies = [
+ "home",
+]
+
+[[package]]
 name = "xplr"
 version = "0.21.2"
 dependencies = [
@@ -1806,8 +1797,8 @@ dependencies = [
  "assert_cmd",
  "criterion",
  "crossterm",
- "dirs",
  "gethostname",
+ "home",
  "humansize",
  "indexmap",
  "jf",
@@ -1830,4 +1821,5 @@ dependencies = [
  "time 0.3.21",
  "tui-input",
  "which",
+ "xdg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,19 +28,20 @@ natord = "1.0.9"
 anyhow = "1.0.71"
 serde_yaml = "0.9.21"
 crossterm = { version = "0.26.1", features = [], default-features = false }
-dirs = "5.0.1"
 ansi-to-tui = "3.0.0"
 regex = "1.8.1"
 gethostname = "0.4.3"
 serde_json = "1.0.96"
 path-absolutize = "3.1.0"
 which = "4.4.0"
-nu-ansi-term = "0.47.0" 
+nu-ansi-term = "0.47.0"
 textwrap = "0.16"
 snailquote = "0.3.1"
 skim = { version = "0.10.4", default-features = false }
 time = { version = "0.3.21", features = ["serde", "local-offset", "formatting", "macros"] }
 jf = "0.3.1"
+xdg = "2.5.0"
+home = "0.5.5"
 
 [dependencies.lscolors]
 version = "0.14.0"

--- a/src/app.rs
+++ b/src/app.rs
@@ -2,6 +2,7 @@ use crate::config::Config;
 use crate::config::Hooks;
 use crate::config::Mode;
 pub use crate::directory_buffer::DirectoryBuffer;
+use crate::dirs;
 use crate::explorer;
 use crate::input::{InputOperation, Key};
 use crate::lua;
@@ -320,7 +321,6 @@ impl App {
 
         let pid = std::process::id();
         let mut session_path = dirs::runtime_dir()
-            .unwrap_or_else(env::temp_dir)
             .join("xplr")
             .join("session")
             .join(pid.to_string())

--- a/src/dirs.rs
+++ b/src/dirs.rs
@@ -21,5 +21,5 @@ pub fn runtime_dir() -> PathBuf {
         .and_then(|base| base.get_runtime_directory().ok()) else {
         return env::temp_dir();
     };
-    return dir.to_owned();
+    dir.to_owned()
 }

--- a/src/dirs.rs
+++ b/src/dirs.rs
@@ -1,0 +1,25 @@
+use std::{env, path::PathBuf};
+
+use lazy_static::lazy_static;
+use xdg::BaseDirectories;
+
+lazy_static! {
+    pub static ref BASE_DIRS: Option<BaseDirectories> = BaseDirectories::new().ok();
+}
+
+pub fn home_dir() -> Option<PathBuf> {
+    home::home_dir()
+}
+
+pub fn config_dir() -> Option<PathBuf> {
+    BASE_DIRS.as_ref().map(|base| base.get_config_home())
+}
+
+pub fn runtime_dir() -> PathBuf {
+    let Some(dir) = BASE_DIRS
+        .as_ref()
+        .and_then(|base| base.get_runtime_directory().ok()) else {
+        return env::temp_dir();
+    };
+    return dir.to_owned();
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod cli;
 pub mod compat;
 pub mod config;
 pub mod directory_buffer;
+pub mod dirs;
 pub mod event_reader;
 pub mod explorer;
 pub mod input;

--- a/src/path.rs
+++ b/src/path.rs
@@ -1,3 +1,4 @@
+use crate::dirs;
 use anyhow::{bail, Result};
 use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};


### PR DESCRIPTION
Alternative solution to #630 to solve #627.

I created a `dirs.rs` module wrapping xdg and also moved the env::temp_dir() fallback for the runtime dir in there as well, since it seemed like a good fit. If you want we could also move more of the config file finding logic here.