### PR TITLE
Enable cancellation of rename & delete mode

### DIFF
--- a/src/init.lua
+++ b/src/init.lua
@@ -1884,6 +1884,12 @@ xplr.config.modes.builtin.rename = {
   name = "rename",
   key_bindings = {
     on_key = {
+      ["esc"] = {
+        help = "cancel",
+        messages = {
+          "PopMode",
+        },
+      },
       ["tab"] = {
         help = "try complete",
         messages = {
@@ -1973,6 +1979,12 @@ xplr.config.modes.builtin.delete = {
   layout = "HelpMenu",
   key_bindings = {
     on_key = {
+      ["esc"] = {
+        help = "cancel",
+        messages = {
+          "PopMode",
+        },
+      },
       ["D"] = {
         help = "force delete",
         messages = {


### PR DESCRIPTION
When using both modes, I don't find a way to cancel and back to previous mode.
Hope this is an expected experience that overlooked.