### PR TITLE
Silently fail to 'enter' regular files

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1035,7 +1035,7 @@ impl App {
 
     fn enter(self) -> Result<Self> {
         if let Some(node) = self.focused_node() {
-            if node.is_dir {
+            if node.is_dir || node.symlink.as_ref().map(|s| s.is_dir).unwrap_or(false) {
                 let path = node.absolute_path.clone();
                 self.change_directory(&path, true)
             } else {

--- a/src/app.rs
+++ b/src/app.rs
@@ -1035,7 +1035,11 @@ impl App {
 
     fn enter(self) -> Result<Self> {
         if let Some(path) = self.focused_node().map(|n| n.absolute_path.clone()) {
-            self.change_directory(&path, true)
+            if PathBuf::from(&path).absolutize()?.to_path_buf().is_dir() {
+                self.change_directory(&path, true)
+            } else {
+                Ok(self)
+            }
         } else {
             Ok(self)
         }

--- a/src/app.rs
+++ b/src/app.rs
@@ -1034,8 +1034,9 @@ impl App {
     }
 
     fn enter(self) -> Result<Self> {
-        if let Some(path) = self.focused_node().map(|n| n.absolute_path.clone()) {
-            if PathBuf::from(&path).absolutize()?.to_path_buf().is_dir() {
+        if let Some(node) = self.focused_node() {
+            if node.is_dir {
+                let path = node.absolute_path.clone();
                 self.change_directory(&path, true)
             } else {
                 Ok(self)


### PR DESCRIPTION
Silently fail to "Enter" regular files. Entering only makes sense for directories.

This fixes https://github.com/sayanarijit/xplr/issues/653#issue-1806818324

I don't know Rust at all, so I make no claims to the code quality. But I have tested this change and it does work.