### PR TITLE
fix node style with no LS_COLORS set

### DIFF
--- a/src/init.lua
+++ b/src/init.lua
@@ -2922,7 +2922,7 @@ xplr.fn.builtin.fmt_general_selection_item = function(n)
   end
   local ls_style = xplr.util.lscolor(n.absolute_path)
   local meta_style = xplr.util.node_type(n).style
-  local style = xplr.util.style_mix({ ls_style, meta_style })
+  local style = xplr.util.style_mix({ meta_style, ls_style })
   return xplr.util.paint(shortened:gsub("\n", nl), style)
 end
 
@@ -2945,7 +2945,7 @@ xplr.fn.builtin.fmt_general_table_row_cols_1 = function(m)
   local nl = xplr.util.paint("\\n", { add_modifiers = { "Italic", "Dim" } })
   local r = m.tree .. m.prefix
   local style = xplr.util.lscolor(m.absolute_path)
-  style = xplr.util.style_mix({ style, m.style })
+  style = xplr.util.style_mix({ m.style, style })
 
   if m.meta.icon == nil then
     r = r .. ""

--- a/src/lua/util.rs
+++ b/src/lua/util.rs
@@ -634,7 +634,7 @@ pub fn to_yaml<'a>(util: Table<'a>, lua: &Lua) -> Result<Table<'a>> {
 /// -- { fg = "Red", bg = nil, add_modifiers = {}, sub_modifiers = {} }
 /// ```
 pub fn lscolor<'a>(util: Table<'a>, lua: &Lua) -> Result<Table<'a>> {
-    let lscolors = LsColors::from_env().unwrap_or_default();
+    let lscolors = LsColors::from_env().unwrap_or(LsColors::empty());
     let func = lua.create_function(move |lua, path: String| {
         let style = lscolors.style_for_path(path).map(Style::from);
         lua::serialize(lua, &style).map_err(LuaError::custom)


### PR DESCRIPTION
Fixing the issue mentioned #651
Instead of calling for default() on LsColors it calls on empty() in order to avoid injecting a default style 
Tested with and without LS_COLORS set and it seems to do the trick