### PR TITLE
init: Fix error upon deleting file on non-GNU systems

### DIFF
--- a/src/init.lua
+++ b/src/init.lua
@@ -1995,7 +1995,9 @@ xplr.config.modes.builtin.delete = {
         messages = {
           {
             BashExec0 = [===[
-              cat "${XPLR_PIPE_RESULT_OUT:?}" | xargs -0 printf '%q\n'
+              while IFS= read -r -d '' PTH; do
+                printf '%q\n' "$PTH"
+              done < "${XPLR_PIPE_RESULT_OUT:?}"
               echo
               read -p "Permanently delete these files? [Y/n]: " ANS
               [ "${ANS:-Y}" = "Y" ] || [ "$ANS" = "y" ] || exit 0
@@ -2023,7 +2025,9 @@ xplr.config.modes.builtin.delete = {
         messages = {
           {
             BashExec0 = [===[
-              cat "${XPLR_PIPE_RESULT_OUT:?}" | xargs -0 printf '%q\n'
+              while IFS= read -r -d '' PTH; do
+                printf '%q\n' "$PTH"
+              done < "${XPLR_PIPE_RESULT_OUT:?}"
               echo
               read -p "Permanently delete these files? [Y/n]: " ANS
               [ "${ANS:-Y}" = "Y" ] || [ "$ANS" = "y" ] || exit 0


### PR DESCRIPTION
When passing arguments to `xargs` binaries can only be used, we cannot use a shells builtin command, so this issue cannot be subverted just by installing bash. In this instance, my systems `printf` implementation does not support the `%q` format specification—specifically a GNU extension. Yielding this error upon trying to delete a file:

```shell
printf: illegal format character q
```

For a more visual example;
```
navi:~
% uname ; man 1 printf | grep '%q' | wc -l
FreeBSD
       0
navi:~
% printf "%q\n" \f \oo 'bar'* baz
printf: illegal format character q
navi:~
% bash -c 'printf "%q\n" \f \oo 'bar'* baz '
f
oo
bar\*
baz
```

Remedying this is just a case of not using `xargs` and instead iterating through each line of the output pipe, then calling bash's builtin `printf` (oppose to an actual binary). While bash is still a hard requirement, this makes things less of a headache for new users on non-GNU-like system, in my case FreeBSD (to my understanding neither of the other BSD's support the %q format, seems to be another GNU-ism).

Retrospectively looking, I can only find `xargs` mentioned in the documentation;

```shell
% git grep 'xargs'
docs/en/src/awesome-hacks.md:            --preview="echo {}|sed 's#.*->  ##'| xargs exa --color=always" \
docs/en/src/awesome-plugins.md:[22]: https://github.com/sayanarijit/xargs.xplr
```

It might be worthwhile combing through the available plugins that may make use of `xargs` and GNU extensions.

Many thanks, and thank you for your continued work on xplr.

Closes: #652