### PR TITLE
cargo: Revert version update on `ansi-to-tui`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,14 +52,12 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "ansi-to-tui"
-version = "4.0.1"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8438af3d7e7dccdb98eff55e5351587d9bec2294daff505fc9a061bd14d22db0"
+checksum = "0b0e348dcd256ba06d44d5deabc88a7c0e80ee7303158253ca069bcd9e9b7f57"
 dependencies = [
  "nom",
  "ratatui",
- "simdutf8",
- "smallvec",
  "thiserror",
 ]
 
@@ -1336,12 +1334,6 @@ checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "simdutf8"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
 
 [[package]]
 name = "skim"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ natord = "1.0.9"
 anyhow = "1.0.81"
 serde_yaml = "0.9.33"
 crossterm = { version = "0.27.0", features = [], default-features = false }
-ansi-to-tui = "4.0.1"
+ansi-to-tui = "3.1.0"
 regex = "1.10.3"
 gethostname = "0.4.3"
 serde_json = "1.0.114"


### PR DESCRIPTION
which apparently causes custom styling to be lost on the currently selected line.

I noticed that the last version increase contained a bunch of dependency updates (#700). One of the updated dependencies was `ansi-to-tui`, which had a major version increase from 3 to 4. Unfortunately [their Changelog][1] isn't up to date, but in the Git history I found [this commit][2] which, as far as I can tell, changes [the handling of the reset ANSI code][3], probably justifying the major version increase.

Before the update (or with this patch applied), my active line looks like this: 

![image](https://github.com/sayanarijit/xplr/assets/99636919/696a1db7-16ae-4305-93fb-0d0cddd43856)

whereas with the current version, I get this:

![image](https://github.com/sayanarijit/xplr/assets/99636919/1994ecd0-da97-4f5b-bbc0-d9e693e1a8d1)

As far as I can tell this change was introduced in 9db8b2cc190c98e532cf511cc9c1b39663f1343b, but at a quick glance I don't see an immediate connection between the code added there and the theming issues I experience now (apart from the version bump in `ansi-to-tui`). Maybe the code needs to be patched, or the theming in my config is broken? In any case, this PR "fixes" the issue for me.

[1]: https://github.com/uttarayan21/ansi-to-tui/blob/f09f5b7b7f2c321f2c5814de39b2d2c86af2f2cd/CHANGELOG.md
[2]: https://github.com/uttarayan21/ansi-to-tui/commit/5c458c9428a514ab1e9e74319002a65c2a221238
[3]: https://github.com/uttarayan21/ansi-to-tui/commit/5c458c9428a514ab1e9e74319002a65c2a221238#diff-4a04259da480a6b794a2e947e4cc03eff4d1aa9330836f5b91cac68c5398193fL45