### PR TITLE
cargo: allow building with system lua

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ features = ['serde']
 
 [dependencies.mlua]
 version = "0.9.6"
-features = ['luajit', 'vendored', 'serialize', 'send']
+features = ['luajit', 'serialize', 'send']
 
 [dependencies.tui-input]
 version = "0.8.0"
@@ -90,5 +90,7 @@ panic = 'abort'
 strip = true
 
 [features]
+default = ["vendored-lua"]
+vendored-lua = ["mlua/vendored"]
 
 


### PR DESCRIPTION
useful for distros  

---

no change in default behaviour, but allows passing `--no-default-features` which makes mlua look up luajit via pkg-config to link to a system library. distros already patch this, so this lets them do it with no patch :)