### PR TITLE
Adds Vim-Like Scrolling to XPLR

### DIFF
--- a/benches/criterion.rs
+++ b/benches/criterion.rs
@@ -121,7 +121,7 @@ fn draw_benchmark(c: &mut Criterion) {
 
     c.bench_function("draw on terminal", |b| {
         b.iter(|| {
-            terminal.draw(|f| ui::draw(f, &app, &lua)).unwrap();
+            terminal.draw(|f| ui::draw(f, &mut app, &lua)).unwrap();
         })
     });
 

--- a/docs/en/src/general-config.md
+++ b/docs/en/src/general-config.md
@@ -42,6 +42,12 @@ Set it to `true` if you want to hide all remaps in the help menu.
 
 Type: boolean
 
+#### xplr.config.general.vimlike_scrolling
+
+Set it to `true` if you want vim-like scrolling.
+
+Type: boolean
+
 #### xplr.config.general.enforce_bounded_index_navigation
 
 Set it to `true` if you want the cursor to stay in the same position when

--- a/src/app.rs
+++ b/src/app.rs
@@ -754,7 +754,7 @@ impl App {
             focus.as_ref().map(PathBuf::from),
             self.directory_buffer
                 .as_ref()
-                .map(|d| d.scroll_state.current_focus)
+                .map(|d| d.scroll_state.get_focus())
                 .unwrap_or(0),
         ) {
             Ok(dir) => self.set_directory(dir),
@@ -825,15 +825,15 @@ impl App {
         let bounded = self.config.general.enforce_bounded_index_navigation;
 
         if let Some(dir) = self.directory_buffer_mut() {
-            if dir.scroll_state.current_focus == 0 {
+            if dir.scroll_state.get_focus() == 0 {
                 if bounded {
-                    dir.scroll_state.set_focus(dir.scroll_state.current_focus);
+                    dir.scroll_state.set_focus(dir.scroll_state.get_focus());
                 } else {
                     dir.scroll_state.set_focus(dir.total.saturating_sub(1));
                 }
             } else {
                 dir.scroll_state
-                    .set_focus(dir.scroll_state.current_focus.saturating_sub(1));
+                    .set_focus(dir.scroll_state.get_focus().saturating_sub(1));
             };
         };
         Ok(self)
@@ -887,7 +887,7 @@ impl App {
             }
 
             dir.scroll_state
-                .set_focus(dir.scroll_state.current_focus.saturating_sub(index));
+                .set_focus(dir.scroll_state.get_focus().saturating_sub(index));
             if let Some(n) = self.focused_node() {
                 self.history = history.push(n.absolute_path.clone());
             }
@@ -912,15 +912,15 @@ impl App {
         let bounded = self.config.general.enforce_bounded_index_navigation;
 
         if let Some(dir) = self.directory_buffer_mut() {
-            if (dir.scroll_state.current_focus + 1) == dir.total {
+            if (dir.scroll_state.get_focus() + 1) == dir.total {
                 if bounded {
-                    dir.scroll_state.set_focus(dir.scroll_state.current_focus);
+                    dir.scroll_state.set_focus(dir.scroll_state.get_focus());
                 } else {
                     dir.scroll_state.set_focus(0);
                 }
             } else {
                 dir.scroll_state
-                    .set_focus(dir.scroll_state.current_focus + 1);
+                    .set_focus(dir.scroll_state.get_focus() + 1);
             }
         };
         Ok(self)
@@ -975,7 +975,7 @@ impl App {
 
             dir.scroll_state.set_focus(
                 dir.scroll_state
-                    .current_focus
+                    .get_focus()
                     .saturating_add(index)
                     .min(dir.total.saturating_sub(1)),
             );

--- a/src/app.rs
+++ b/src/app.rs
@@ -826,9 +826,7 @@ impl App {
 
         if let Some(dir) = self.directory_buffer_mut() {
             if dir.scroll_state.get_focus() == 0 {
-                if bounded {
-                    dir.scroll_state.set_focus(dir.scroll_state.get_focus());
-                } else {
+                if !bounded {
                     dir.scroll_state.set_focus(dir.total.saturating_sub(1));
                 }
             } else {
@@ -913,9 +911,7 @@ impl App {
 
         if let Some(dir) = self.directory_buffer_mut() {
             if (dir.scroll_state.get_focus() + 1) == dir.total {
-                if bounded {
-                    dir.scroll_state.set_focus(dir.scroll_state.get_focus());
-                } else {
+                if !bounded {
                     dir.scroll_state.set_focus(0);
                 }
             } else {

--- a/src/app.rs
+++ b/src/app.rs
@@ -915,8 +915,7 @@ impl App {
                     dir.scroll_state.set_focus(0);
                 }
             } else {
-                dir.scroll_state
-                    .set_focus(dir.scroll_state.get_focus() + 1);
+                dir.scroll_state.set_focus(dir.scroll_state.get_focus() + 1);
             }
         };
         Ok(self)

--- a/src/config.rs
+++ b/src/config.rs
@@ -353,6 +353,9 @@ pub struct GeneralConfig {
 
     #[serde(default)]
     pub global_key_bindings: KeyBindings,
+
+    #[serde(default)]
+    pub vimlike_scrolling: bool,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/directory_buffer.rs
+++ b/src/directory_buffer.rs
@@ -18,7 +18,12 @@ impl ScrollState {
         self.current_focus = current_focus;
     }
 
-    pub fn calc_skipped_rows(&mut self, height: usize, total: usize) -> usize {
+    pub fn calc_skipped_rows(
+        &mut self,
+        height: usize,
+        total: usize,
+        vimlike_scrolling: bool,
+    ) -> usize {
         let current_focus = self.current_focus;
         let last_focus = self.last_focus;
         let first_visible_row = self.skipped_rows;
@@ -26,9 +31,7 @@ impl ScrollState {
         let end_cushion_row = (first_visible_row + height)
             .saturating_sub(ScrollState::PREVIEW_CUSHION + 1);
 
-        let vim_scrolling_enabled = true;
-
-        if !vim_scrolling_enabled {
+        if !vimlike_scrolling {
             height * (self.current_focus / height.max(1))
         } else if last_focus == None {
             // Just entered the directory

--- a/src/directory_buffer.rs
+++ b/src/directory_buffer.rs
@@ -11,7 +11,7 @@ pub struct ScrollState {
 
 impl ScrollState {
     /* The number of visible next lines when scrolling towards either ends of the view port */
-    pub const PREVIEW_CUSHION: usize = 3;
+    pub const PREVIEW_CUSHION: usize = 5;
 
     pub fn set_focus(&mut self, current_focus: usize) {
         self.last_focus = Some(self.current_focus);

--- a/src/directory_buffer.rs
+++ b/src/directory_buffer.rs
@@ -1,5 +1,3 @@
-use std::thread::current;
-
 use crate::node::Node;
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
@@ -52,7 +50,7 @@ impl ScrollState {
             // When focus goes to last node
             total.saturating_sub(height)
         } else if (start_cushion_row..=end_cushion_row).contains(&current_focus) {
-            // IF within cushioned area; do nothing
+            // If within cushioned area; do nothing
             first_visible_row
         } else if current_focus > last_focus.unwrap() {
             // When scrolling down outside the view port

--- a/src/directory_buffer.rs
+++ b/src/directory_buffer.rs
@@ -3,30 +3,92 @@ use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ScrollState {
+    pub current_focus: usize,
+    pub last_focus: Option<usize>,
+    pub skipped_rows: usize,
+}
+
+impl ScrollState {
+    /* The number of visible next lines when scrolling towards either ends of the view port */
+    pub const PREVIEW_CUSHION: usize = 3;
+
+    pub fn set_focus(&mut self, current_focus: usize) {
+        self.last_focus = Some(self.current_focus);
+        self.current_focus = current_focus;
+    }
+
+    pub fn calc_skipped_rows(&mut self, height: usize, total: usize) -> usize {
+        let current_focus = self.current_focus;
+        let last_focus = self.last_focus;
+        let first_visible_row = self.skipped_rows;
+        let start_cushion_row = first_visible_row + ScrollState::PREVIEW_CUSHION;
+        let end_cushion_row = (first_visible_row + height)
+            .saturating_sub(ScrollState::PREVIEW_CUSHION + 1);
+
+        let vim_scrolling_enabled = true;
+
+        if !vim_scrolling_enabled {
+            height * (self.current_focus / height.max(1))
+        } else if last_focus == None {
+            // Just entered the directory
+            0
+        } else if current_focus == 0 {
+            0
+        } else if current_focus == total.saturating_sub(1) {
+            total.saturating_sub(height)
+        } else if current_focus > last_focus.unwrap() {
+            // Scrolling down
+            if current_focus <= end_cushion_row {
+                first_visible_row
+            } else if total <= (current_focus + ScrollState::PREVIEW_CUSHION) {
+                first_visible_row
+            } else {
+                (self.current_focus + ScrollState::PREVIEW_CUSHION + 1)
+                    .saturating_sub(height)
+            }
+        } else {
+            // Scrolling up
+            if current_focus >= start_cushion_row {
+                first_visible_row
+            } else if current_focus <= ScrollState::PREVIEW_CUSHION {
+                0
+            } else {
+                current_focus.saturating_sub(ScrollState::PREVIEW_CUSHION)
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct DirectoryBuffer {
     pub parent: String,
     pub nodes: Vec<Node>,
     pub total: usize,
-    pub focus: usize,
+    pub scroll_state: ScrollState,
 
     #[serde(skip, default = "now")]
     pub explored_at: OffsetDateTime,
 }
 
 impl DirectoryBuffer {
-    pub fn new(parent: String, nodes: Vec<Node>, focus: usize) -> Self {
+    pub fn new(parent: String, nodes: Vec<Node>, current_focus: usize) -> Self {
         let total = nodes.len();
         Self {
             parent,
             nodes,
             total,
-            focus,
+            scroll_state: ScrollState {
+                current_focus,
+                last_focus: None,
+                skipped_rows: 0,
+            },
             explored_at: now(),
         }
     }
 
     pub fn focused_node(&self) -> Option<&Node> {
-        self.nodes.get(self.focus)
+        self.nodes.get(self.scroll_state.current_focus)
     }
 }
 

--- a/src/directory_buffer.rs
+++ b/src/directory_buffer.rs
@@ -4,7 +4,7 @@ use time::OffsetDateTime;
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct ScrollState {
-    pub current_focus: usize,
+    current_focus: usize,
     pub last_focus: Option<usize>,
     pub skipped_rows: usize,
 }
@@ -16,6 +16,10 @@ impl ScrollState {
     pub fn set_focus(&mut self, current_focus: usize) {
         self.last_focus = Some(self.current_focus);
         self.current_focus = current_focus;
+    }
+
+    pub fn get_focus(&self) -> usize {
+        self.current_focus
     }
 
     pub fn calc_skipped_rows(

--- a/src/directory_buffer.rs
+++ b/src/directory_buffer.rs
@@ -23,7 +23,7 @@ impl ScrollState {
     }
 
     pub fn calc_skipped_rows(
-        &mut self,
+        &self,
         height: usize,
         total: usize,
         vimlike_scrolling: bool,

--- a/src/directory_buffer.rs
+++ b/src/directory_buffer.rs
@@ -12,7 +12,6 @@ pub struct ScrollState {
 }
 
 impl ScrollState {
-
     pub fn set_focus(&mut self, current_focus: usize) {
         self.last_focus = Some(self.current_focus);
         self.current_focus = current_focus;
@@ -48,9 +47,9 @@ impl ScrollState {
             .saturating_sub(preview_cushion + 1)
             .min(total.saturating_sub(preview_cushion + 1));
 
-        let new_skipped_rows = if !vimlike_scrolling {
+        if !vimlike_scrolling {
             height * (self.current_focus / height.max(1))
-        } else if last_focus == None {
+        } else if last_focus.is_none() {
             // Just entered the directory
             0
         } else if current_focus == 0 {
@@ -86,9 +85,7 @@ impl ScrollState {
         } else {
             // If nothing matches; do nothing
             first_visible_row
-        };
-
-        new_skipped_rows
+        }
     }
 }
 

--- a/src/directory_buffer.rs
+++ b/src/directory_buffer.rs
@@ -110,3 +110,106 @@ fn now() -> OffsetDateTime {
         .ok()
         .unwrap_or_else(OffsetDateTime::now_utc)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_calc_skipped_rows_non_vimlike_scrolling() {
+        let mut state = ScrollState {
+            current_focus: 10,
+            last_focus: Some(8),
+            skipped_rows: 0,
+        };
+
+        let height = 5;
+        let total = 20;
+        let vimlike_scrolling = false;
+
+        let result = state.calc_skipped_rows(height, total, vimlike_scrolling);
+        assert_eq!(result, height * (state.current_focus / height.max(1)));
+    }
+
+    #[test]
+    fn test_calc_skipped_rows_entered_directory() {
+        let mut state = ScrollState {
+            current_focus: 10,
+            last_focus: None,
+            skipped_rows: 0,
+        };
+
+        let height = 5;
+        let total = 20;
+        let vimlike_scrolling = true;
+
+        let result = state.calc_skipped_rows(height, total, vimlike_scrolling);
+        assert_eq!(result, 0);
+    }
+
+    #[test]
+    fn test_calc_skipped_rows_top_of_directory() {
+        let mut state = ScrollState {
+            current_focus: 0,
+            last_focus: Some(8),
+            skipped_rows: 5,
+        };
+
+        let height = 5;
+        let total = 20;
+        let vimlike_scrolling = true;
+
+        let result = state.calc_skipped_rows(height, total, vimlike_scrolling);
+        assert_eq!(result, 0);
+    }
+
+    #[test]
+    fn test_calc_skipped_rows_bottom_of_directory() {
+        let mut state = ScrollState {
+            current_focus: 19,
+            last_focus: Some(18),
+            skipped_rows: 15,
+        };
+
+        let height = 5;
+        let total = 20;
+        let vimlike_scrolling = true;
+
+        let result = state.calc_skipped_rows(height, total, vimlike_scrolling);
+        assert_eq!(result, 15);
+    }
+
+    #[test]
+    fn test_calc_skipped_rows_scrolling_down() {
+        let mut state = ScrollState {
+            current_focus: 12,
+            last_focus: Some(10),
+            skipped_rows: 10,
+        };
+
+        let height = 5;
+        let total = 20;
+        let vimlike_scrolling = true;
+
+        let result = state.calc_skipped_rows(height, total, vimlike_scrolling);
+        assert_eq!(result, 11);
+    }
+
+    #[test]
+    fn test_calc_skipped_rows_scrolling_up() {
+        let mut state = ScrollState {
+            current_focus: 8,
+            last_focus: Some(10),
+            skipped_rows: 10,
+        };
+
+        let height = 5;
+        let total = 20;
+        let vimlike_scrolling = true;
+
+        let result = state.calc_skipped_rows(height, total, vimlike_scrolling);
+        assert_eq!(result, 5);
+    }
+
+    // Add more tests for other scenarios...
+}

--- a/src/directory_buffer.rs
+++ b/src/directory_buffer.rs
@@ -31,18 +31,22 @@ impl ScrollState {
         let current_focus = self.current_focus;
         let last_focus = self.last_focus;
         let first_visible_row = self.skipped_rows;
+
+        // Calculate the cushion rows at the start and end of the view port
         let start_cushion_row = first_visible_row + ScrollState::PREVIEW_CUSHION;
         let end_cushion_row = (first_visible_row + height)
             .saturating_sub(ScrollState::PREVIEW_CUSHION + 1);
 
-        if !vimlike_scrolling {
+        let new_skipped_rows = if !vimlike_scrolling {
             height * (self.current_focus / height.max(1))
         } else if last_focus == None {
             // Just entered the directory
             0
         } else if current_focus == 0 {
+            // Focus on first node
             0
         } else if current_focus == total.saturating_sub(1) {
+            // Focus on last node
             total.saturating_sub(height)
         } else if current_focus > last_focus.unwrap() {
             // Scrolling down
@@ -63,7 +67,9 @@ impl ScrollState {
             } else {
                 current_focus.saturating_sub(ScrollState::PREVIEW_CUSHION)
             }
-        }
+        };
+
+        new_skipped_rows
     }
 }
 

--- a/src/directory_buffer.rs
+++ b/src/directory_buffer.rs
@@ -53,24 +53,24 @@ impl ScrollState {
             // If within cushioned area; do nothing
             first_visible_row
         } else if current_focus > last_focus.unwrap() {
-            // When scrolling down outside the view port
+            // When scrolling down the cushioned area
             if current_focus > total.saturating_sub(ScrollState::PREVIEW_CUSHION + 1) {
                 // When focusing the last nodes; always view the full last page
                 total.saturating_sub(height)
             } else {
-                // When scrolling down the view port without reaching the last nodes
+                // When scrolling down the cushioned area without reaching the last nodes
                 current_focus.saturating_sub(height - 1 - ScrollState::PREVIEW_CUSHION)
             }
         } else if current_focus < last_focus.unwrap() {
-            // When scrolling up outside the view port
+            // When scrolling up the cushioned area
             if current_focus < ScrollState::PREVIEW_CUSHION {
                 // When focusing the first nodes; always view the full first page
                 0
             } else if current_focus > end_cushion_row {
-                // When scrolling up around from the last rows; do nothing
+                // When scrolling up from the last rows; do nothing
                 first_visible_row
             } else {
-                // When scrolling up the view port without reaching the first nodes
+                // When scrolling up the cushioned area without reaching the first nodes
                 current_focus.saturating_sub(ScrollState::PREVIEW_CUSHION)
             }
         } else {

--- a/src/init.lua
+++ b/src/init.lua
@@ -91,6 +91,11 @@ xplr.config.general.enable_recover_mode = false
 -- Type: boolean
 xplr.config.general.hide_remaps_in_help_menu = false
 
+-- Set it to `true` if you want vim-like scrolling.
+--
+-- Type: boolean
+xplr.config.general.vimlike_scrolling = false
+
 -- Set it to `true` if you want the cursor to stay in the same position when
 -- the focus is on the first path and you navigate to the previous path
 -- (by pressing `up`/`k`), or when the focus is on the last path and you

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -27,8 +27,8 @@ use tui::Terminal;
 use tui_input::Input;
 
 pub fn get_tty() -> Result<fs::File> {
-    let tty = "/dev/stdout";
-    match fs::File::create(tty) {
+    let tty = "/dev/tty";
+    match fs::OpenOptions::new().read(true).write(true).open(tty) {
         Ok(f) => Ok(f),
         Err(e) => {
             bail!(format!("could not open {tty}. {e}"))

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -89,7 +89,7 @@ fn call(
     let focus_index = app
         .directory_buffer
         .as_ref()
-        .map(|d| d.focus)
+        .map(|d| d.scroll_state.current_focus)
         .unwrap_or_default()
         .to_string();
 
@@ -279,7 +279,10 @@ impl Runner {
             app.explorer_config.clone(),
             app.pwd.clone().into(),
             self.focused_path,
-            app.directory_buffer.as_ref().map(|d| d.focus).unwrap_or(0),
+            app.directory_buffer
+                .as_ref()
+                .map(|d| d.scroll_state.current_focus)
+                .unwrap_or(0),
             tx_msg_in.clone(),
         );
         tx_pwd_watcher.send(app.pwd.clone())?;
@@ -430,7 +433,7 @@ impl Runner {
                                         .map(|n| n.relative_path.clone().into()),
                                     app.directory_buffer
                                         .as_ref()
-                                        .map(|d| d.focus)
+                                        .map(|d| d.scroll_state.current_focus)
                                         .unwrap_or(0),
                                     tx_msg_in.clone(),
                                 );
@@ -445,7 +448,7 @@ impl Runner {
                                         .map(|n| n.relative_path.clone().into()),
                                     app.directory_buffer
                                         .as_ref()
-                                        .map(|d| d.focus)
+                                        .map(|d| d.scroll_state.current_focus)
                                         .unwrap_or(0),
                                     tx_msg_in.clone(),
                                 );
@@ -493,7 +496,7 @@ impl Runner {
                                 }
 
                                 // UI
-                                terminal.draw(|f| ui::draw(f, &app, &lua))?;
+                                terminal.draw(|f| ui::draw(f, &mut app, &lua))?;
                             }
 
                             EnableMouse => {

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -27,8 +27,8 @@ use tui::Terminal;
 use tui_input::Input;
 
 pub fn get_tty() -> Result<fs::File> {
-    let tty = "/dev/tty";
-    match fs::OpenOptions::new().read(true).write(true).open(tty) {
+    let tty = "/dev/stdout";
+    match fs::File::create(tty) {
         Ok(f) => Ok(f),
         Err(e) => {
             bail!(format!("could not open {tty}. {e}"))

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -89,7 +89,7 @@ fn call(
     let focus_index = app
         .directory_buffer
         .as_ref()
-        .map(|d| d.scroll_state.current_focus)
+        .map(|d| d.scroll_state.get_focus())
         .unwrap_or_default()
         .to_string();
 
@@ -281,7 +281,7 @@ impl Runner {
             self.focused_path,
             app.directory_buffer
                 .as_ref()
-                .map(|d| d.scroll_state.current_focus)
+                .map(|d| d.scroll_state.get_focus())
                 .unwrap_or(0),
             tx_msg_in.clone(),
         );
@@ -433,7 +433,7 @@ impl Runner {
                                         .map(|n| n.relative_path.clone().into()),
                                     app.directory_buffer
                                         .as_ref()
-                                        .map(|d| d.scroll_state.current_focus)
+                                        .map(|d| d.scroll_state.get_focus())
                                         .unwrap_or(0),
                                     tx_msg_in.clone(),
                                 );
@@ -448,7 +448,7 @@ impl Runner {
                                         .map(|n| n.relative_path.clone().into()),
                                     app.directory_buffer
                                         .as_ref()
-                                        .map(|d| d.scroll_state.current_focus)
+                                        .map(|d| d.scroll_state.get_focus())
                                         .unwrap_or(0),
                                     tx_msg_in.clone(),
                                 );

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -737,7 +737,11 @@ fn draw_table(
         .directory_buffer
         .as_mut()
         .map(|dir| {
-            dir.scroll_state.skipped_rows = dir.scroll_state.calc_skipped_rows(height, dir.total);
+            dir.scroll_state.skipped_rows = dir.scroll_state.calc_skipped_rows(
+                height,
+                dir.total,
+                app.config.general.vimlike_scrolling,
+            );
             dir.nodes
                 .iter()
                 .enumerate()

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -748,7 +748,7 @@ fn draw_table(
                 .skip(dir.scroll_state.skipped_rows)
                 .take(height)
                 .map(|(index, node)| {
-                    let is_focused = dir.scroll_state.current_focus == index;
+                    let is_focused = dir.scroll_state.get_focus() == index;
 
                     let is_selected = app
                         .selection
@@ -777,12 +777,12 @@ fn draw_table(
                     let node_type = app_config.node_types.get(node);
 
                     let (relative_index, is_before_focus, is_after_focus) =
-                        match dir.scroll_state.current_focus.cmp(&index) {
+                        match dir.scroll_state.get_focus().cmp(&index) {
                             Ordering::Greater => {
-                                (dir.scroll_state.current_focus - index, true, false)
+                                (dir.scroll_state.get_focus() - index, true, false)
                             }
                             Ordering::Less => {
-                                (index - dir.scroll_state.current_focus, false, true)
+                                (index - dir.scroll_state.get_focus(), false, true)
                             }
                             Ordering::Equal => (0, false, false),
                         };


### PR DESCRIPTION
- Added through a setting `vimlike_scrolling` which is turned off by default
- A hard-coded _(for now)_ cushion of `5` lines that allows for previewing the next lines while scrolling
- A separate struct `ScrollState` with getters and setters for the `current_focus` field to disallow setting the field without updating the `last_focus` field