### PR TITLE
Fix crash when tab completing an empty string (#736)

### DIFF
--- a/src/init.lua
+++ b/src/init.lua
@@ -3060,7 +3060,7 @@ xplr.config.modes.custom = {}
 
 -- Tries to auto complete the path in the input buffer
 xplr.fn.builtin.try_complete_path = function(m)
-  if not m.input_buffer then
+  if not m.input_buffer or m.input_buffer == "" then
     return
   end
 


### PR DESCRIPTION
This PR fixes issue #736 by adding a check for empty user input when tab completing a path (`src/init.lua` : `try_complete_path`)

Fix has been tested on multiple systems, does not interfere with other functionality.