### PR TITLE
fix: imv preview compatibility with filenames containing spaces or long paths

### DIFF
--- a/docs/en/src/awesome-hacks.md
+++ b/docs/en/src/awesome-hacks.md
@@ -418,7 +418,6 @@ done <"$FIFO_PATH"
 
 imv-msg "$IMV_PID" quit
 [ -e "$FIFO_PATH" ] && rm -f -- "$FIFO_PATH"
-...
   ```
 
 

--- a/docs/en/src/awesome-hacks.md
+++ b/docs/en/src/awesome-hacks.md
@@ -418,7 +418,6 @@ done <"$FIFO_PATH"
 
 imv-msg "$IMV_PID" quit
 [ -e "$FIFO_PATH" ] && rm -f -- "$FIFO_PATH"
-'''
 
 </details>
 

--- a/docs/en/src/awesome-hacks.md
+++ b/docs/en/src/awesome-hacks.md
@@ -400,13 +400,25 @@ sleep 0.5
 xdotool windowactivate "$MAINWINDOW"
 
 while read -r path; do
+
+  hash=$(echo "$path" | sha1sum | awk '{print $1}')
+
+  ext="${path##*.}"
+  [[ "$ext" == "$path" ]] && ext="img"
+
+  tmp_path="/tmp/imv_symlink_${hash}.${ext}"
+
+  ln -sf "$path" "$tmp_path"
+
   imv-msg "$IMV_PID" close all
-  imv-msg "$IMV_PID" open "$path"
-done < "$FIFO_PATH"
+  imv-msg "$IMV_PID" open "$tmp_path"
+
+  (sleep 2 && rm -f "$tmp_path") &
+done <"$FIFO_PATH"
 
 imv-msg "$IMV_PID" quit
 [ -e "$FIFO_PATH" ] && rm -f -- "$FIFO_PATH"
-```
+'''
 
 </details>
 

--- a/docs/en/src/awesome-hacks.md
+++ b/docs/en/src/awesome-hacks.md
@@ -418,7 +418,7 @@ done <"$FIFO_PATH"
 
 imv-msg "$IMV_PID" quit
 [ -e "$FIFO_PATH" ] && rm -f -- "$FIFO_PATH"
-```
+...
   ```
 
 

--- a/docs/en/src/awesome-hacks.md
+++ b/docs/en/src/awesome-hacks.md
@@ -418,6 +418,9 @@ done <"$FIFO_PATH"
 
 imv-msg "$IMV_PID" quit
 [ -e "$FIFO_PATH" ] && rm -f -- "$FIFO_PATH"
+```
+  ```
+
 
 </details>
 


### PR DESCRIPTION
This PR improves the existing `Image viewer (imv)` hack to handle paths containing spaces or long filenames that break `imv-msg`.

Instead of passing the path directly, the Bash script now:
- Creates a symlink with a hashed name in `/tmp`
- Sends that symlink to `imv-msg`
- Automatically deletes the symlink after a short delay to keep `/tmp` clean

Tested on:
- Linux (EndeavourOS)
- i3 + picom + kitty
- xplr 0.21+