### PR TITLE
allow reading of luajit bytecode as init files

### DIFF
--- a/src/lua/mod.rs
+++ b/src/lua/mod.rs
@@ -93,7 +93,7 @@ pub fn init(lua: &Lua) -> Result<(Config, Option<Hooks>)> {
 pub fn extend(lua: &Lua, path: &str) -> Result<(Config, Option<Hooks>)> {
     let globals = lua.globals();
 
-    let script = fs::read_to_string(path)?;
+    let script = fs::read(path)?;
 
     let hooks: Option<Hooks> = lua
         .load(&script)


### PR DESCRIPTION
allow reading non-utf8 init files and not error on loading bytecode.

note: the benefits in startup time are minimal.