### PR TITLE
refactor(ci): rewrite snapcraft deployment and add edge channel support

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -139,24 +139,39 @@ jobs:
           basename "${{ steps.snapcraft.outputs.snap }}"
 
       - name: Prepare snap for GitHub Release
+        if: startsWith(github.ref, 'refs/tags/v')
+        id: snap_prepare_github_release
         run: |
-          SNAP_FILE="${{ steps.snapcraft.outputs.snap }}"
-          cp "$SNAP_FILE" xplr.snap
-          echo "Prepared xplr.snap for GitHub Release"
+          VERSION="${GITHUB_REF#refs/tags/v}"
+          ARCH=$(basename: "${{ steps.snapcraft.outputs.snap }}" |\
+                 grep -oP '_\K[^_]+(?=\.snap$)')
+          case "$ARCH" in
+            amd64) STANDARD_ARCH="x86_64"  ;;
+            arm64) STANDARD_ARCH="aarch64" ;;
+            armhf) STANDARD_ARCH="arm"     ;;
+            *)     STANDARD_ARCH="$ARCH"   ;;
+          esac
+
+          # SEMANTIC_NAME="xplr-v${VERSION}-linux-${STANDARD_ARCH}.snap"
+          SEMANTIC_NAME="xplr-v${VERSION}.snap"
+          cp "${{ steps.snapcraft.outputs.snap }}" "$SEMANTIC_NAME"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "arch=$STANDARD_ARCH" >> "$GITHUB_OUTPUT"
+          echo "snap_file=$SEMANTIC_NAME" >> "$GITHUB_OUTPUT"
+          echo "Prepared $SEMANTIC_NAME for GitHub Release"
 
       - name: Publish to Snapcraft Store
-        if: startsWith(github.ref, 'refs/tags/v')
         uses: snapcore/action-publish@v1
         with:
           snap: ${{ steps.snapcraft.outputs.snap }}
-          release: stable
+          release: ${{ startsWith(github.ref, 'refs/tags/v') && 'stable' || 'edge' }}
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
 
       - name: Upload snap to GitHub Release
         uses: softprops/action-gh-release@v1
         with:
-          files: xplr.snap
+          files: ${{ steps.snap_prepare_github_release.outputs.snap_filename }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -157,7 +157,7 @@ jobs:
           cp "${{ steps.snapcraft.outputs.snap }}" "$SEMANTIC_NAME"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "arch=$STANDARD_ARCH" >> "$GITHUB_OUTPUT"
-          echo "snap_file=$SEMANTIC_NAME" >> "$GITHUB_OUTPUT"
+          echo "snap_filename=$SEMANTIC_NAME" >> "$GITHUB_OUTPUT"
           echo "Prepared $SEMANTIC_NAME for GitHub Release"
 
       - name: Publish to Snapcraft Store

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -48,7 +48,7 @@ jobs:
             target: arm-unknown-linux-gnueabihf
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Installing Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -65,9 +65,6 @@ jobs:
         run: |
           sudo apt-get update --fix-missing
           sudo apt-get install -y --no-install-recommends liblua5.1-0-dev libluajit-5.1-dev gcc pkg-config curl git make ca-certificates
-          sudo apt-get install -y snapd
-          # sudo snap install snapcraft --classic
-          # sudo snap install multipass --classic --beta
 
       # - if: matrix.build == 'linux-musl'
       #   run: sudo apt-get install -y musl-tools
@@ -83,13 +80,6 @@ jobs:
 
       - name: Running cargo build
         run: cargo build --locked --release --target ${{ matrix.target }}
-
-      # - name: Running snapcraft build
-      #   run: |
-      #     snapcraft
-      #     printf ' [ INFO ] generated <snapcraft> files include:\n'
-      #     command ls -Al | grep "\.snap" | awk '{ print $9 }'
-      #     mv ./*.snap ./xplr.snap
 
       - name: Install gpg secret key
         run: |
@@ -113,20 +103,68 @@ jobs:
             target/${{ matrix.target }}/release/xplr-${{ matrix.build }}.tar.gz
             target/${{ matrix.target }}/release/xplr-${{ matrix.build }}.sha256
             target/${{ matrix.target }}/release/xplr-${{ matrix.build }}.tar.gz.asc
-            xplr.snap
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # - name: Cleaning snapcraft
-      #   run: |
-      #     command rm --verbose ./*.snap
-      #     snapcraft clean
+  publish-snapcraft:
+    name: Publishing Snap Package
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install and configure LXD
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y lxd lxd-client
+          sudo lxd init --auto
+          sudo usermod --append --groups lxd "$USER"
+          # Verify LXD is ready
+          sg lxd -c "lxc version"
+
+      - name: Build snap package
+        uses: snapcore/action-build@v1
+        id: snapcraft
+        with:
+          snapcraft-args: "--use-lxd"
+
+      - name: Display snap build info
+        run: |
+          echo "=== Built snap file ==="
+          echo "${{ steps.snapcraft.outputs.snap }}"
+          echo ""
+          echo "=== Snap file details ==="
+          ls -la "${{ steps.snapcraft.outputs.snap }}"
+          echo ""
+          echo "=== Snap file name ==="
+          basename "${{ steps.snapcraft.outputs.snap }}"
+
+      - name: Prepare snap for GitHub Release
+        run: |
+          SNAP_FILE="${{ steps.snapcraft.outputs.snap }}"
+          cp "$SNAP_FILE" xplr.snap
+          echo "Prepared xplr.snap for GitHub Release"
+
+      - name: Publish to Snapcraft Store
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: snapcore/action-publish@v1
+        with:
+          snap: ${{ steps.snapcraft.outputs.snap }}
+          release: stable
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
+
+      - name: Upload snap to GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: xplr.snap
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   publish-gpg-signature:
     name: Publishing GPG signature
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install gpg secret key
         run: |
           cat <(echo -e "${{ secrets.GPG_SECRET }}") | gpg --batch --import
@@ -151,7 +189,7 @@ jobs:
     name: Publishing to Cargo
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -114,11 +114,11 @@ jobs:
 
       - name: Install and configure LXD
         run: |
-          sudo apt-get update
-          sudo apt-get install -y lxd lxd-client
+          # sudo apt-get update
+          # sudo apt-get install -y lxd lxd-client # NOT SUPPORTED AFTER U.18
+          sudo snap install lxd
           sudo lxd init --auto
           sudo usermod --append --groups lxd "$USER"
-          # Verify LXD is ready
           sg lxd -c "lxc version"
 
       - name: Build snap package

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -6,9 +6,9 @@ description: |
   interface to explore your filesystem, and perform batch operations efficiently.
 source-code: https://github.com/sayanarijit/xplr
 issues: https://github.com/sayanarijit/xplr/issues
-website: https://xplr.dev/source-code:
+website: https://xplr.dev
 
-base: core20
+base: core22
 grade: stable
 confinement: strict
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -2,25 +2,31 @@ name: xplr
 version: git
 summary: A hackable, minimal, fast TUI file explorer
 description: |
-  xplr is a terminal UI based file explorer
-  that aims to increase our terminal productivity by being a flexible,
-  interactive orchestrator for the ever growing awesome command-line
-  utilities that work with the file-system.
+  xplr is a hackable, minimal, fast TUI file explorer, giving you a terminal
+  interface to explore your filesystem, and perform batch operations efficiently.
 source-code: https://github.com/sayanarijit/xplr
 issues: https://github.com/sayanarijit/xplr/issues
-website: https://xplr.dev/
+website: https://xplr.dev/source-code:
 
 base: core20
-grade: devel # must be 'stable' to release into candidate/stable channels
-confinement: devmode # use 'strict' once you have the right plugs and slots
-
+grade: stable
+confinement: strict
 
 parts:
   xplr:
     plugin: rust
     source: .
+    build-packages:
+      - liblua5.1-0-dev
+      - libluajit-5.1-dev
+      - pkg-config
+      - gcc
+      - make
 
 apps:
   xplr:
     command: bin/xplr
-
+    plugs:
+      - home
+      - removable-media
+      - network


### PR DESCRIPTION
This PR completely re-engineers the `publish-snapcraft` job in our CD pipeline. 

Along with fixing the malformed `snapcraft.yaml` that was blocking our builds, I've rewritten the workflow to modernize how we handle Snap packages:
- Introduced automatic publishing to the `edge` channel on pushes to `main`, so users can easily test upcoming changes.
- Improved the GitHub Release step to output semantically named snap files (matching our binary naming convention).
- Cleaned up the LXD initialization and fixed a few bash syntax quirks.

Thanks so much for your time and for maintaining xplr!

---

Resolves #695 