### PR TITLE
docs: fix nonexistent util function in upgrade guide

### DIFF
--- a/docs/en/src/upgrade-guide.md
+++ b/docs/en/src/upgrade-guide.md
@@ -128,7 +128,7 @@ such collaborations in the future.
 - Also check out the following utility functions:
   - xplr.util.layout_replace
   - xplr.util.relative_to
-  - xplr.util.shorthand
+  - xplr.util.shorten
   - xplr.util.clone
   - xplr.util.exists
   - xplr.util.is_dir


### PR DESCRIPTION
`docs/en/src/upgrade-guide.md` lists `xplr.util.shorthand` under the current utility functions, but there is no `shorthand` function. The real one is `xplr.util.shorten` (registered in `src/lua/util.rs` and documented in `docs/en/src/xplr.util.md`), so this corrects the name.
