### PR TITLE
fix: use portable mkdir for create_file mode

### DIFF
--- a/src/init.lua
+++ b/src/init.lua
@@ -1955,8 +1955,8 @@ xplr.config.modes.builtin.create_file = {
               PTH="$XPLR_INPUT_BUFFER"
               PTH_ESC=$(printf %q "$PTH")
               if [ "$PTH" ]; then
-                mkdir -p -- "$(dirname $(realpath -m $PTH))"  # This may fail.
-                touch -- "$PTH" \
+                mkdir -p -- "$(dirname -- "$PTH")" \
+                && touch -- "$PTH" \
                 && "$XPLR" -m 'SetInputBuffer: ""' \
                 && "$XPLR" -m 'LogSuccess: %q' "$PTH_ESC created" \
                 && "$XPLR" -m 'ExplorePwd' \


### PR DESCRIPTION
Fixes #770

## Summary
The create_file mode used `realpath -m` which is not portable (macOS doesn't support the -m flag). Changed to use `dirname` directly like the create_conditional mode does.

## Changes
- Modified `src/init.lua` create_file mode to use portable `mkdir -p -- "$(dirname -- "$PTH")"`

## Testing
- This ensures parent directories are created when creating a file with a nested path like `parser/mod.rs`
- Matches the behavior of create_conditional mode which already works correctly